### PR TITLE
Add MapLibre as a Swift Package, MapLibre `ios-v5.9.11`

### DIFF
--- a/mapbox-gl-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/mapbox-gl-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,6 +14,8 @@
 		117741E0255A2B9200D4866F /* AWSSignatureV4Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741DF255A2B9200D4866F /* AWSSignatureV4Delegate.swift */; };
 		117741E3255A2D5200D4866F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741E2255A2D5200D4866F /* MapView.swift */; };
 		B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5270A22DC16E59A33EA1537 /* Pods_Amazon_Location_Service_Demo.framework */; };
+		D7CB7CF425C3412500F63D73 /* MapboxMobileEvents in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */; };
+		D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF525C3412500F63D73 /* Mapbox */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +37,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */,
+				D7CB7CF425C3412500F63D73 /* MapboxMobileEvents in Frameworks */,
 				B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -117,6 +121,10 @@
 			dependencies = (
 			);
 			name = "Amazon Location Service Demo";
+			packageProductDependencies = (
+				D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */,
+				D7CB7CF525C3412500F63D73 /* Mapbox */,
+			);
 			productName = "Amazon Location Service Demo";
 			productReference = 117741C7255A216600D4866F /* Amazon Location Service Demo.app */;
 			productType = "com.apple.product-type.application";
@@ -144,6 +152,9 @@
 				Base,
 			);
 			mainGroup = 117741BE255A216600D4866F;
+			packageReferences = (
+				D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+			);
 			productRefGroup = 117741C8255A216600D4866F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -406,6 +417,30 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.10.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MapboxMobileEvents;
+		};
+		D7CB7CF525C3412500F63D73 /* Mapbox */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = Mapbox;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 117741BF255A216600D4866F /* Project object */;
 }

--- a/mapbox-gl-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/mapbox-gl-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		117741E0255A2B9200D4866F /* AWSSignatureV4Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741DF255A2B9200D4866F /* AWSSignatureV4Delegate.swift */; };
 		117741E3255A2D5200D4866F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741E2255A2D5200D4866F /* MapView.swift */; };
 		B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5270A22DC16E59A33EA1537 /* Pods_Amazon_Location_Service_Demo.framework */; };
-		D7CB7CF425C3412500F63D73 /* MapboxMobileEvents in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */; };
 		D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF525C3412500F63D73 /* Mapbox */; };
 /* End PBXBuildFile section */
 
@@ -38,7 +37,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */,
-				D7CB7CF425C3412500F63D73 /* MapboxMobileEvents in Frameworks */,
 				B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -122,7 +120,6 @@
 			);
 			name = "Amazon Location Service Demo";
 			packageProductDependencies = (
-				D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */,
 				D7CB7CF525C3412500F63D73 /* Mapbox */,
 			);
 			productName = "Amazon Location Service Demo";
@@ -424,17 +421,12 @@
 			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.10.0;
+				minimumVersion = 5.11.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		D7CB7CF325C3412500F63D73 /* MapboxMobileEvents */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
-			productName = MapboxMobileEvents;
-		};
 		D7CB7CF525C3412500F63D73 /* Mapbox */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;

--- a/mapbox-gl-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mapbox-gl-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,12 +2,12 @@
   "object": {
     "pins": [
       {
-        "package": "maplibre-gl-native",
+        "package": "MapLibre GL Native",
         "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
-          "revision": "7eaf6a9741e1a2bd698c4dfc4184cfa138f2aba3",
-          "version": "5.10.0"
+          "revision": "dc28d9ad9e1b5c52cdeab26e2fe1781db4974e9a",
+          "version": "5.11.0"
         }
       }
     ]

--- a/mapbox-gl-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mapbox-gl-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "maplibre-gl-native",
+        "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
+        "state": {
+          "branch": null,
+          "revision": "7eaf6a9741e1a2bd698c4dfc4184cfa138f2aba3",
+          "version": "5.10.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/mapbox-gl-native-ios/Podfile
+++ b/mapbox-gl-native-ios/Podfile
@@ -7,5 +7,4 @@ target 'Amazon Location Service Demo' do
   use_frameworks!
 
   pod 'AWSCore'
-  pod 'Mapbox-iOS-SDK', '~> 5.9.0'
 end

--- a/mapbox-gl-native-ios/Podfile.lock
+++ b/mapbox-gl-native-ios/Podfile.lock
@@ -1,24 +1,16 @@
 PODS:
   - AWSCore (2.19.1)
-  - Mapbox-iOS-SDK (5.9.0):
-    - MapboxMobileEvents (= 0.10.2)
-  - MapboxMobileEvents (0.10.2)
 
 DEPENDENCIES:
   - AWSCore
-  - Mapbox-iOS-SDK (~> 5.9.0)
 
 SPEC REPOS:
   trunk:
     - AWSCore
-    - Mapbox-iOS-SDK
-    - MapboxMobileEvents
 
 SPEC CHECKSUMS:
   AWSCore: 55c154ae27efc5c98bdc30a0eeea5a35d10a2ab5
-  Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
-  MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
 
-PODFILE CHECKSUM: b9d3b28135ec8e606105223adf1f0e4f8669cff6
+PODFILE CHECKSUM: ce10d51c7e0402b58a1b252bcc7e330d73a9d529
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.1

--- a/mapbox-gl-native-ios/Podfile.lock
+++ b/mapbox-gl-native-ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AWSCore (2.19.1)
+  - AWSCore (2.23.0)
 
 DEPENDENCIES:
   - AWSCore
@@ -9,7 +9,7 @@ SPEC REPOS:
     - AWSCore
 
 SPEC CHECKSUMS:
-  AWSCore: 55c154ae27efc5c98bdc30a0eeea5a35d10a2ab5
+  AWSCore: 589ad0bd5b72e9a95ce33834f12339b50cfc9f14
 
 PODFILE CHECKSUM: ce10d51c7e0402b58a1b252bcc7e330d73a9d529
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

* Remove references to Mapbox in the `Podfile`
* Add MapLibre as a Swift Package from https://github.com/maptiler/maplibre-gl-native-distribution
* Tested with Xcode Version 12.4 (12D4e)

*Figure 1:  Swift Package Dependencies in the Project Navigator View*

<img width="213" alt="figure-1-Swift Package Dependencies in the Project Navigator View" src="https://user-images.githubusercontent.com/118112/106188439-ce89fd00-615b-11eb-8a32-ae3df63b1f0e.png">

---

*Figure 2:  Project `Amazon Location Service Demo` in the Swift Packages View*

<img width="512" alt="figure-2-Project in the Swift Packages View" src="https://user-images.githubusercontent.com/118112/106188463-d77ace80-615b-11eb-944e-eff70a1a6c53.png">


---

*Figure 3: Add Package to `Amazon Location Service Demo` in the Swift Packages View*

<img width="400" alt="Figure 3- Add Package to in the Swift Packages View" src="https://user-images.githubusercontent.com/118112/106188474-dc3f8280-615b-11eb-90ff-7f849ee8ded9.png">


---

*Figure 4: Embedded MapLibre Libraries in the Target View*

<img width="373" alt="Figure 4- Embedded MapLibre Libraries in the Target View" src="https://user-images.githubusercontent.com/118112/106188489-e06ba000-615b-11eb-8833-242095709652.png">
