### PR TITLE
Add MapLibre for Android 9.2.1 & 9.4.0

### DIFF
--- a/mapbox-gl-native-android/app/build.gradle
+++ b/mapbox-gl-native-android/app/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation 'org.maplibre.gl:android-sdk:9.2.1'
+    implementation 'org.maplibre.gl:android-sdk:9.4.0'
     implementation 'com.amazonaws:aws-android-sdk-core:2.20.0'
 }

--- a/mapbox-gl-native-android/app/build.gradle
+++ b/mapbox-gl-native-android/app/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation 'com.amazonaws:aws-android-sdk-core:2.19.0'
     implementation 'org.maplibre.gl:android-sdk:9.2.1'
+    implementation 'com.amazonaws:aws-android-sdk-core:2.20.0'
 }

--- a/mapbox-gl-native-android/app/build.gradle
+++ b/mapbox-gl-native-android/app/build.gradle
@@ -38,5 +38,5 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'com.amazonaws:aws-android-sdk-core:2.19.0'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.2.1'
+    implementation 'org.maplibre.gl:android-sdk:9.2.1'
 }

--- a/mapbox-gl-native-android/app/build.gradle
+++ b/mapbox-gl-native-android/app/build.gradle
@@ -39,4 +39,5 @@ dependencies {
 
     implementation 'org.maplibre.gl:android-sdk:9.4.0'
     implementation 'com.amazonaws:aws-android-sdk-core:2.20.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.3'
 }

--- a/mapbox-gl-native-android/app/src/main/java/aws/location/demo/mapboxgl/MainActivity.kt
+++ b/mapbox-gl-native-android/app/src/main/java/aws/location/demo/mapboxgl/MainActivity.kt
@@ -37,7 +37,6 @@ class MainActivity : AppCompatActivity() {
 
         // initialize Mapbox GL
         Mapbox.getInstance(this, null)
-        Mapbox.getTelemetry()?.disableTelemetrySession()
         HttpRequestUtil.setOkHttpClient(
             OkHttpClient.Builder()
                 .addInterceptor(SigV4Interceptor(credentialProvider, SERVICE_NAME))

--- a/mapbox-gl-native-android/build.gradle
+++ b/mapbox-gl-native-android/build.gradle
@@ -18,6 +18,10 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            // for org.maplibre.gl:android-sdk
+            url = "https://dl.bintray.com/maplibre/maplibre-gl-native"
+        }
     }
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

* Add the Bintray Maven URL at `allprojects.repositories` in `build.gradle` (Project: Amazon_Location_Service_Demo)
* Update `dependencies` in `build.gradle` (Module: Amazon_Location_Service_Demo.app)

*Figure 1:  The two `build.gradle` files to update*

<img width="455" alt="maplibre-android-2" src="https://user-images.githubusercontent.com/118112/106208492-55e56980-6178-11eb-930a-3e88cf0848ec.png">

---

*Figure 2:  Result of `.aar` after adding MapLibre*
<img width="400" alt="maplibre-android" src="https://user-images.githubusercontent.com/118112/106207913-5fba9d00-6177-11eb-9bc9-9e4c3ae13f0a.png">

---

*Figure 3: The view of the Mapbox `.aar`'s, before switching to MapLibre*

<img width="500" alt="maplibre-android" src="https://user-images.githubusercontent.com/118112/106210655-1587ea80-617c-11eb-9913-840956cecfa0.png">

