### PR TITLE
Upgrade aws-amplify

### DIFF
--- a/mapbox-gl-js-react/package-lock.json
+++ b/mapbox-gl-js-react/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "@aws-amplify/analytics": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-4.0.5.tgz",
-      "integrity": "sha512-1tjp+56JiW8hdFbhUnnHTBxQsZWCqJQ4YyV1fE4Q2LHbKFPU37ou1nS9EQSlz+9euBt0JBv3EPd+4MmydDfARQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-4.0.7.tgz",
+      "integrity": "sha512-q9mvla8mTDLAChuvVWDGjI0Q2pECalNbvNddccsSfEbf+mfhSlgl2zC0xwAM9b89OANWvMaHqgtKvk7RVDRA+g==",
       "requires": {
-        "@aws-amplify/cache": "3.1.42",
-        "@aws-amplify/core": "3.8.9",
+        "@aws-amplify/cache": "3.1.44",
+        "@aws-amplify/core": "3.8.11",
         "@aws-sdk/client-firehose": "1.0.0-rc.4",
         "@aws-sdk/client-kinesis": "1.0.0-rc.4",
         "@aws-sdk/client-personalize-events": "1.0.0-rc.4",
@@ -21,61 +21,61 @@
       }
     },
     "@aws-amplify/api": {
-      "version": "3.2.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.2.17.tgz",
-      "integrity": "sha512-apXk9CcRuKQ9tmIP4sJuahDwPBWEq5IVu88uA+4DWZaReVbJ6vITW2R4a2eW9S1c54ev47hWdcxq7r4d85019g==",
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.2.19.tgz",
+      "integrity": "sha512-xAiNbfWIbwSiLhsTidogDEbzyxxcKVaKKQn+mkSGVCCV5tY7UOKcJxQ2+++atFwh3xwdfypug/1FvRD5c43N7Q==",
       "requires": {
-        "@aws-amplify/api-graphql": "1.2.17",
-        "@aws-amplify/api-rest": "1.2.17"
+        "@aws-amplify/api-graphql": "1.2.19",
+        "@aws-amplify/api-rest": "1.2.19"
       }
     },
     "@aws-amplify/api-graphql": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.2.17.tgz",
-      "integrity": "sha512-7YYWYMTQUhkJjnE0x31Khnp9MyEFbrJKnnZlwaCUdQsL21f94UwfHhcll3ewduhbl0jmfb2jnxMi3R25snQWqw==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.2.19.tgz",
+      "integrity": "sha512-6PyWbPzAnbb2q42Ak0fkBwifsQ2gPoR8NZCOI2xJIHq3HNNukLcjEkLlPWk0oZumDR2AqJXCTdmWmyzUta6sAg==",
       "requires": {
-        "@aws-amplify/api-rest": "1.2.17",
-        "@aws-amplify/auth": "3.4.17",
-        "@aws-amplify/cache": "3.1.42",
-        "@aws-amplify/core": "3.8.9",
-        "@aws-amplify/pubsub": "3.2.15",
+        "@aws-amplify/api-rest": "1.2.19",
+        "@aws-amplify/auth": "3.4.19",
+        "@aws-amplify/cache": "3.1.44",
+        "@aws-amplify/core": "3.8.11",
+        "@aws-amplify/pubsub": "3.2.17",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.17.tgz",
-      "integrity": "sha512-gP9pDy527jVvHtVUMbueHlwIOj9592NTmOAJfeuYod58BgQs4NGZQnHa8zIF4bw8FOUrG+kr3RKpDSCnCibkpQ==",
+      "version": "1.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.19.tgz",
+      "integrity": "sha512-qjByVJCc+nOg/tH2dUQBgcvRvRtgLERKc7f+Jq5zhOdZZkwhlpQ/UhLbiH4OY087LQYr/j1eAOXh/xmS4UJkvQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.9",
+        "@aws-amplify/core": "3.8.11",
         "axios": "0.21.1"
       }
     },
     "@aws-amplify/auth": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.4.17.tgz",
-      "integrity": "sha512-/AZUpqRQJOYocLajIKGGqTxB9RJuZxJruhHchStTmAyV/B2x5j6aNOU0x3mSoBc/AUFsH7MZsFophxfHUwMQUg==",
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.4.19.tgz",
+      "integrity": "sha512-j6FokO8ih08aUorM6695WfPc9KA4wGX9r5foYi4ZbFUBKtcUZvEkf5Cm3mR4Xq3gRYqL5TSJoiMDzatjr+rwlw==",
       "requires": {
-        "@aws-amplify/cache": "3.1.42",
-        "@aws-amplify/core": "3.8.9",
-        "amazon-cognito-identity-js": "4.5.7",
+        "@aws-amplify/cache": "3.1.44",
+        "@aws-amplify/core": "3.8.11",
+        "amazon-cognito-identity-js": "4.5.9",
         "crypto-js": "^3.3.0"
       }
     },
     "@aws-amplify/cache": {
-      "version": "3.1.42",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.42.tgz",
-      "integrity": "sha512-tsXgB1wSDCYW19pWeHfPCcO7FraIL6VSoo6uNwWjWPaTtnYKxtKKYzg/alQ9RLWnP6AEa+dLrEkZspBbg1UlOw==",
+      "version": "3.1.44",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.44.tgz",
+      "integrity": "sha512-WA+gIEmo4GSd7zlGe+tTYm/vRiDGN3vuSuHvJY1fBuaI2hrO4h2Popyf3N6VCaoRjvJrZL9fTsyRBNqYx7gXLQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.9"
+        "@aws-amplify/core": "3.8.11"
       }
     },
     "@aws-amplify/core": {
-      "version": "3.8.9",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.8.9.tgz",
-      "integrity": "sha512-YYuq+A21i5tzXxNLL65pYVY9VuPD5NuOvpL64C8FbyPgYax88OpOREhXj9UBvOA/IbfnN5tuTAOwaW7rlGXR2A==",
+      "version": "3.8.11",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.8.11.tgz",
+      "integrity": "sha512-Z42qml2QM0v0jQ9fANHFJG1Fd060gHJ/UiRf7WanVSgDegVuorfyyTiovJiIoDeGgGVhA/LexOmkYlzwdCWAyw==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
         "@aws-sdk/client-cognito-identity": "1.0.0-rc.4",
@@ -87,15 +87,15 @@
       }
     },
     "@aws-amplify/datastore": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.9.3.tgz",
-      "integrity": "sha512-5eDfAHoJR2txxQSQbI23jQAveME9ZWqKasRCc88MJsjAznVtrft+hDEEbcPby1FuSdkGlpdLbhds8rjNkOzZKw==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.9.5.tgz",
+      "integrity": "sha512-2W3aIMT/pQa9AKLCctxh1B0w9v6nXQjar0Nq1Hxc7ZM9lzZSbT5j7/hWd6cn5pejpT/8F7dohmNOU30OknNMEw==",
       "requires": {
-        "@aws-amplify/api": "3.2.17",
-        "@aws-amplify/core": "3.8.9",
-        "@aws-amplify/pubsub": "3.2.15",
+        "@aws-amplify/api": "3.2.19",
+        "@aws-amplify/core": "3.8.11",
+        "@aws-amplify/pubsub": "3.2.17",
         "idb": "5.0.6",
-        "immer": "6.0.1",
+        "immer": "8.0.1",
         "ulid": "2.3.0",
         "uuid": "3.3.2",
         "zen-observable-ts": "0.8.19",
@@ -110,21 +110,21 @@
       }
     },
     "@aws-amplify/interactions": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.3.17.tgz",
-      "integrity": "sha512-3GMCnw3tIAlLtehokI9V75ZMH3MUCUd04MyyiJzE8uXtgFE1WEzvgBTVskGMQ2g2Au3vRZyl5l8TYPnDVAK0Gw==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.3.19.tgz",
+      "integrity": "sha512-/BYUYShsBhDyZ+6I1EXBTXB3mge7hsOb8ojd9JCoV/CIOzsuE0Bg1QkGvrnZDiLTiXB5m9nXDJ23HQrVAilbDw==",
       "requires": {
-        "@aws-amplify/core": "3.8.9",
+        "@aws-amplify/core": "3.8.11",
         "@aws-sdk/client-lex-runtime-service": "1.0.0-rc.4"
       }
     },
     "@aws-amplify/predictions": {
-      "version": "3.2.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.2.17.tgz",
-      "integrity": "sha512-GUt/mXu0JbxdzcJgt+zip7BNNpi3dxnF89TOK/SsYWyMcHCu7Cvz1RLieQKG9PIJ7w7ZOwdHj9KEU7zSFuNvEQ==",
+      "version": "3.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.2.19.tgz",
+      "integrity": "sha512-NHegpU95mBn8CrgjjF46jsuIB/ib8HE5mvFTq2csnzga1p7oB3sRCzrmC+YrX79d1wNp0ECNPBVc4DTcFIc0gg==",
       "requires": {
-        "@aws-amplify/core": "3.8.9",
-        "@aws-amplify/storage": "3.3.17",
+        "@aws-amplify/core": "3.8.11",
+        "@aws-amplify/storage": "3.3.19",
         "@aws-sdk/client-comprehend": "1.0.0-rc.4",
         "@aws-sdk/client-polly": "1.0.0-rc.4",
         "@aws-sdk/client-rekognition": "1.0.0-rc.4",
@@ -136,13 +136,13 @@
       }
     },
     "@aws-amplify/pubsub": {
-      "version": "3.2.15",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.2.15.tgz",
-      "integrity": "sha512-9+416AADtghiCKYBc1130Fkue3tcJsV8B5pCYXKa/NZXMwD9kiAFMqoVXhJTR0HlCxV6C6+Hf6LgXFMfiZ2Quw==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.2.17.tgz",
+      "integrity": "sha512-ygEKxDgM4yrtqYQ+BiquLh5KVNAmp/c2VxkoNXlrEMgsg5y+7hQSfjEQqMNfo8pi3mhKcLs6ht3g67+4SVlBdg==",
       "requires": {
-        "@aws-amplify/auth": "3.4.17",
-        "@aws-amplify/cache": "3.1.42",
-        "@aws-amplify/core": "3.8.9",
+        "@aws-amplify/auth": "3.4.19",
+        "@aws-amplify/cache": "3.1.44",
+        "@aws-amplify/core": "3.8.11",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -150,11 +150,11 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.3.17.tgz",
-      "integrity": "sha512-uA5NOd59r6clS6UyCHvNPPJjXuW5x3xHK/b11iagQVM2VVt5EI1HeGGCIQZU2CJuILSdB8Hn6HJIUp5+EpM+tw==",
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.3.19.tgz",
+      "integrity": "sha512-G5MWYsFj6INsoQgoj3TCYOzVX5V0T9ia7Vz95LD+5b+SBzo1BqVMYEwR7Rtcs47ubTiH7n4QPVc3ZuDLbyDb0g==",
       "requires": {
-        "@aws-amplify/core": "3.8.9",
+        "@aws-amplify/core": "3.8.11",
         "@aws-sdk/client-s3": "1.0.0-rc.4",
         "@aws-sdk/s3-request-presigner": "1.0.0-rc.4",
         "@aws-sdk/util-create-request": "1.0.0-rc.4",
@@ -170,11 +170,11 @@
       "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
     },
     "@aws-amplify/xr": {
-      "version": "2.2.17",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.2.17.tgz",
-      "integrity": "sha512-7P8nk/VEKIznadtovvo83bG0uG1XEohtfTJYyEK4+W0JuCL8ws1EQd9EH5R4msFG8r2IrT2miQVpSargVaUfSA==",
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.2.19.tgz",
+      "integrity": "sha512-+viu7aM5IhsirwY3ds7B7S5AGNp91fZhOlwkxJiJoI8dfFZa9mq7WP9pgU3svIGw0t9oh8FHYIA9KKEO3Fy4+Q==",
       "requires": {
-        "@aws-amplify/core": "3.8.9"
+        "@aws-amplify/core": "3.8.11"
       }
     },
     "@aws-crypto/crc32": {
@@ -194,27 +194,40 @@
       }
     },
     "@aws-crypto/sha256-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0.tgz",
-      "integrity": "sha512-uSufui4ZktC5lYX6bDxgBgNboxGyw9V9V+rlcNsNTxh4YPhOdCslwJMGntiWOBRGAgXhhvWi7FqnTS2SaT3cpg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
       "requires": {
         "@aws-crypto/ie11-detection": "^1.0.0",
-        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
         "@aws-crypto/supports-web-crypto": "^1.0.0",
-        "@aws-sdk/types": "^1.0.0-rc.1",
-        "@aws-sdk/util-locate-window": "^1.0.0-rc.1",
-        "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+          "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+          "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+          "requires": {
+            "tslib": "^1.8.0"
           }
         }
       }
@@ -302,15 +315,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -365,15 +391,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -427,15 +466,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -492,15 +544,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -554,15 +619,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -616,15 +694,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -678,15 +769,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -740,15 +844,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -802,15 +919,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -878,15 +1008,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -940,15 +1083,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -1003,15 +1159,28 @@
       },
       "dependencies": {
         "@aws-crypto/sha256-js": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz",
-          "integrity": "sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+          "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
           "requires": {
-            "@aws-sdk/types": "^1.0.0-rc.1",
-            "@aws-sdk/util-utf8-browser": "^1.0.0-rc.1",
+            "@aws-sdk/types": "^3.1.0",
+            "@aws-sdk/util-utf8-browser": "^3.0.0",
             "tslib": "^1.11.1"
           },
           "dependencies": {
+            "@aws-sdk/types": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.4.1.tgz",
+              "integrity": "sha512-HqDPRdMzseVD4I/8Bb8TBAzg2X0U7oDiPfvYcvZt8fpVO2SwBOiLMh9tiEnRin48uRBbQMAw8D8wmCpyU78Dvg=="
+            },
+            "@aws-sdk/util-utf8-browser": {
+              "version": "3.4.1",
+              "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.4.1.tgz",
+              "integrity": "sha512-dZ13D/y0cqFAe6LlWa17BXseRzRh96i8Jdx23I8zNSTcXctIetqINMwtO9KeJMl20vQTj8iORb4J496FgVRuUA==",
+              "requires": {
+                "tslib": "^1.8.0"
+              }
+            },
             "tslib": {
               "version": "1.14.1",
               "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -1591,9 +1760,9 @@
       }
     },
     "@aws-sdk/util-locate-window": {
-      "version": "1.0.0-rc.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-1.0.0-rc.8.tgz",
-      "integrity": "sha512-TvqeA4fgmZ0A0x3K+qVj/OSWEFHGZjzpVuyXlm1EYOf7NQ9VWRlokEn1MYKuL+t7al9ZeQyi16D8Dn7DW1eidw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.4.1.tgz",
+      "integrity": "sha512-wjN2FWqlPDek9WIvwLeRCjjbf3P2751j2DL0EOUHmm231gpCCGfiV1Ykb1ZY9iKlYkFumybs8C+5QOQXTrQUlg==",
       "requires": {
         "tslib": "^1.8.0"
       }
@@ -4427,9 +4596,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "amazon-cognito-identity-js": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.5.7.tgz",
-      "integrity": "sha512-ecdLY8A3SnG3vaAQPxAskCHPvbzpo0f8tIEVN1xacoI/+qfbbvG3pENFSBbHeuBjwvmQpxOBhQ0tRdy1o7nURA==",
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.5.9.tgz",
+      "integrity": "sha512-avPdNaBKJ95GRz4WA5fB9BU8U5sxWhbF5N9XZ1egUndd1OXrPmlCxC9c+XwtPBi7UYfWXimYceIl6gGi3z86Kw==",
       "requires": {
         "buffer": "4.9.1",
         "crypto-js": "^3.3.0",
@@ -4713,22 +4882,22 @@
       }
     },
     "aws-amplify": {
-      "version": "3.3.14",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.3.14.tgz",
-      "integrity": "sha512-5UrGnpvgsB1NLKvq5LAWL6aDzn91gx5i/IEV/khihdVjF+3P+1YU0q3eXLXbKS6gQKWEN9kcUm/uGzGPVa8dEA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.3.16.tgz",
+      "integrity": "sha512-zSpniIOpigRNIThd0tagVdvHcEweknX8sC3aNcW5CVH554+dlpPsWXxoWHrquiUqwy0/GRLL+dmKkiMEuSCx8Q==",
       "requires": {
-        "@aws-amplify/analytics": "4.0.5",
-        "@aws-amplify/api": "3.2.17",
-        "@aws-amplify/auth": "3.4.17",
-        "@aws-amplify/cache": "3.1.42",
-        "@aws-amplify/core": "3.8.9",
-        "@aws-amplify/datastore": "2.9.3",
-        "@aws-amplify/interactions": "3.3.17",
-        "@aws-amplify/predictions": "3.2.17",
-        "@aws-amplify/pubsub": "3.2.15",
-        "@aws-amplify/storage": "3.3.17",
+        "@aws-amplify/analytics": "4.0.7",
+        "@aws-amplify/api": "3.2.19",
+        "@aws-amplify/auth": "3.4.19",
+        "@aws-amplify/cache": "3.1.44",
+        "@aws-amplify/core": "3.8.11",
+        "@aws-amplify/datastore": "2.9.5",
+        "@aws-amplify/interactions": "3.3.19",
+        "@aws-amplify/predictions": "3.2.19",
+        "@aws-amplify/pubsub": "3.2.17",
+        "@aws-amplify/storage": "3.3.19",
         "@aws-amplify/ui": "2.0.2",
-        "@aws-amplify/xr": "2.2.17"
+        "@aws-amplify/xr": "2.2.19"
       }
     },
     "aws-sign2": {
@@ -4755,9 +4924,9 @@
       },
       "dependencies": {
         "follow-redirects": {
-          "version": "1.13.1",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
-          "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+          "version": "1.13.2",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+          "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
         }
       }
     },
@@ -9222,9 +9391,9 @@
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "immer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-6.0.1.tgz",
-      "integrity": "sha512-oXwigCKgznQywsXi1VgrqgWbQEU3wievNCVc4Fcwky6mwXU6YHj6JuYp0WEM/B1EphkqsLr0x18lm5OiuemPcA=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -14384,9 +14553,9 @@
       }
     },
     "react-native-get-random-values": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.5.0.tgz",
-      "integrity": "sha512-LK+Wb8dEimJkd/dub7qziDmr9Tw4chhpzVeQ6JDo4czgfG4VXbptRyOMdu8503RiMF6y9pTH6ZUTkrrpprqT7w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.5.1.tgz",
+      "integrity": "sha512-L76sTcz3jdFmc7Gn41SHOxCioYY3m4rtuWEUI6X8IeWVmkflHXrSyAObOW4eNTM5qytH+45pgMCVKJzfB/Ik4A==",
       "requires": {
         "fast-base64-decode": "^1.0.0"
       }

--- a/mapbox-gl-js-react/package.json
+++ b/mapbox-gl-js-react/package.json
@@ -7,7 +7,7 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
-    "aws-amplify": "^3.3.14",
+    "aws-amplify": "^3.3.16",
     "mapbox-gl": "^1.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",


### PR DESCRIPTION
Upgrades `aws-amplify` to 3.3.16.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
