### PR TITLE
Infer regionId from the identityPoolId.

### DIFF
--- a/tangram-es-android/app/src/main/java/aws/location/demo/tangram/MainActivity.kt
+++ b/tangram-es-android/app/src/main/java/aws/location/demo/tangram/MainActivity.kt
@@ -58,10 +58,11 @@ class MainActivity : AppCompatActivity(), MapView.MapReadyCallback {
     private fun getHttpHandler(): HttpHandler {
         val builder = DefaultHttpHandler.getClientBuilder()
 
+        val identityPoolId = getString(R.string.identityPoolId)
         val credentialsProvider = CognitoCachingCredentialsProvider(
             applicationContext,
-            getString(R.string.identityPoolId),
-            Regions.US_EAST_1
+            identityPoolId,
+            Regions.fromName(identityPoolId.split(":").first())
         )
 
         return DefaultHttpHandler(


### PR DESCRIPTION
The current version of MainActivity was inlining identityPoolId and region for the CognitoCachingCredentialsProvider independently. 

The more streamlined version would be to infer the region from the cognitoIdentityPool id, following the similar pattern as per 
MapLibre example:
https://github.com/aws-samples/amazon-location-samples/blob/main/maplibre-native-android/app/src/main/java/aws/location/demo/mapboxgl/MainActivity.kt#L32-L35

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
