### PR TITLE
Android update mavencentral

### DIFF
--- a/maplibre-native-android/app/build.gradle
+++ b/maplibre-native-android/app/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 android {
     compileSdkVersion 30
-    buildToolsVersion "30.0.2"
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         applicationId "aws.location.demo.mapboxgl"
@@ -34,10 +34,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     implementation 'org.maplibre.gl:android-sdk:9.4.0'
-    implementation 'com.amazonaws:aws-android-sdk-core:2.20.0'
+    implementation 'com.amazonaws:aws-android-sdk-core:2.23.0'
     implementation 'com.squareup.okhttp3:okhttp:3.12.3'
 }

--- a/maplibre-native-android/build.gradle
+++ b/maplibre-native-android/build.gradle
@@ -18,10 +18,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven {
-            // for org.maplibre.gl:android-sdk
-            url = "https://dl.bintray.com/maplibre/maplibre-gl-native"
-        }
+        mavenCentral()
     }
 }
 

--- a/maplibre-native-android/build.gradle
+++ b/maplibre-native-android/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = "1.4.10"
+    ext.kotlin_version = "1.4.31"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.1.0"
+        classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

* Update MapLibre maven dependences for Android based on https://github.com/maplibre/maplibre-gl-native/pull/77
