### PR TITLE
Update the Tangram SDK.

### DIFF
--- a/tangram-es-android/app/build.gradle
+++ b/tangram-es-android/app/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.amazonaws:aws-android-sdk-core:2.19.1'
-    implementation 'com.mapzen.tangram:tangram:0.13.0'
+    implementation 'com.mapzen.tangram:tangram:0.16.0'
 }


### PR DESCRIPTION
Updating the Tangram SDK to 0.16.0 to fix 
java.lang.RuntimeException: Unable to create a native Map object! There may be insufficient memory available.

Bumping the SDK version fixes that issue on certain android devices. 
Refer: https://github.com/aws-samples/amazon-location-samples/issues/19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
