### PR TITLE
Upgrade MapLibre to release `android-v9.4.2`

### DIFF
--- a/maplibre-native-android/app/build.gradle
+++ b/maplibre-native-android/app/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
-    implementation 'org.maplibre.gl:android-sdk:9.4.0'
+    implementation 'org.maplibre.gl:android-sdk:9.4.2'
     implementation 'com.amazonaws:aws-android-sdk-core:2.23.0'
     implementation 'com.squareup.okhttp3:okhttp:3.12.3'
 }


### PR DESCRIPTION
* Upgrade MapLibre to release `android-v9.4.2` https://github.com/maplibre/maplibre-gl-native/releases/tag/android-v9.4.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
