### PR TITLE
upgrade maplibre iOS for metal, `5.12.0-pre.1`

### DIFF
--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		117741E3255A2D5200D4866F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741E2255A2D5200D4866F /* MapView.swift */; };
 		B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5270A22DC16E59A33EA1537 /* Pods_Amazon_Location_Service_Demo.framework */; };
 		D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF525C3412500F63D73 /* Mapbox */; };
+		D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */ = {isa = PBXBuildFile; productRef = D7D9C047264494C90053C1AD /* MetalANGLE */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 			files = (
 				D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */,
 				B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */,
+				D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,6 +123,7 @@
 			name = "Amazon Location Service Demo";
 			packageProductDependencies = (
 				D7CB7CF525C3412500F63D73 /* Mapbox */,
+				D7D9C047264494C90053C1AD /* MetalANGLE */,
 			);
 			productName = "Amazon Location Service Demo";
 			productReference = 117741C7255A216600D4866F /* Amazon Location Service Demo.app */;
@@ -431,6 +434,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = Mapbox;
+		};
+		D7D9C047264494C90053C1AD /* MetalANGLE */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MetalANGLE;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
+			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
 				kind = exactVersion;
 				version = "5.12.0-pre.1";

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -420,8 +420,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.11.0;
+				kind = exactVersion;
+				version = "5.12.0-pre.1";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
-          "revision": "dc28d9ad9e1b5c52cdeab26e2fe1781db4974e9a",
-          "version": "5.11.0"
+          "revision": "f79911a42f605cbaa9eb1ee6330b464eac47569d",
+          "version": "5.12.0-pre.1"
         }
       }
     ]

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "MapLibre GL Native",
-        "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
+        "repositoryURL": "https://github.com/maplibre/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
           "revision": "f79911a42f605cbaa9eb1ee6330b464eac47569d",


### PR DESCRIPTION
1.  Upgrade to MapLibre `5.12.0-pre.1`.  Release notes from https://github.com/maplibre/maplibre-gl-native-distribution/releases/tag/5.12.0-pre.1
2. Add a reference to the `MetalANGLE.framework` in the Xcode Target for Amazon Location Service Demo

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


---

*Upgrade to MapLibre using* Swift Package Manager Exact tag: `5.12.0-pre.1`
<img src="https://user-images.githubusercontent.com/118112/117368684-b6bbc680-ae78-11eb-8b69-a43f03547f04.png" width="50%">

---

*View in Swift Package Manager*
<img src="https://user-images.githubusercontent.com/118112/117368837-e8349200-ae78-11eb-8132-c7e8e8457c3d.png" width="50%">


---

*Be sure to reference any new frameworks*
<img src="https://user-images.githubusercontent.com/118112/117368909-03070680-ae79-11eb-995a-2ec93eb0b61a.png" width="50%">


---

*Demo of Esri Dark Canvas with version `5.12.0-pre.1`*
<img src="https://user-images.githubusercontent.com/118112/117369854-60e81e00-ae7a-11eb-8873-be5d1a7d231c.png"  width="50%">


