### PR TITLE
Update MapView to use a SurfaceView + foreground load color.

### DIFF
--- a/maplibre-native-android/app/src/main/res/layout/activity_main.xml
+++ b/maplibre-native-android/app/src/main/res/layout/activity_main.xml
@@ -15,7 +15,10 @@
         app:mapbox_cameraTargetLng="-123.1187"
         app:mapbox_cameraZoom="12"
         app:mapbox_uiAttribution="false"
-        app:mapbox_uiLogo="false" />
+        app:mapbox_uiLogo="false" 
+        app:mapbox_renderTextureMode="true"
+        app:mapbox_renderTextureTranslucentSurface="true"
+        app:mapbox_foregroundLoadColor="@color/white"/>
 
     <TextView
         android:id="@+id/attributionView"


### PR DESCRIPTION
Without this change the MapTiles wouldn't great on the end device as the map style does not have a background layer setup. 

Refer: https://github.com/aws-samples/amazon-location-samples/issues/29

Feature instrumented by MapBox: https://github.com/mapbox/mapbox-gl-native/issues/3040

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
