### PR TITLE
fix: remove MapRequest not exported from react-map-gl

### DIFF
--- a/mapbox-gl-js-react/src/index.tsx
+++ b/mapbox-gl-js-react/src/index.tsx
@@ -8,7 +8,6 @@ import { Signer, ICredentials } from "@aws-amplify/core";
 import { Auth } from "aws-amplify";
 import ReactMapGL, {
   NavigationControl,
-  MapRequest,
   ViewportProps,
 } from "react-map-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
@@ -27,7 +26,10 @@ const mapName = "<MAP_NAME>";
 const transformRequest = (credentials: ICredentials) => (
   url?: string,
   resourceType?: string
-): MapRequest => {
+): { 
+  url: string,
+  headers?: { [key: string]: string },
+ } => {
   // Resolve to an AWS URL
   if (resourceType === "Style" && !url?.includes("://")) {
     url = `https://maps.geo.${amplifyConfig.aws_project_region}.amazonaws.com/maps/v0/maps/${url}/style-descriptor`;


### PR DESCRIPTION
Hi, thank you for your work. This sample is helpful in learning Amazon Location Service ! I hope this PR would make a little contribute to this by fixing a compile error I found.

`react-map-gl` doesn't seem to export` MapRequest` or similar modules. I think it should be fixed not to import this to avoid errors.

![image](https://user-images.githubusercontent.com/6966113/119464312-913a2280-bd7d-11eb-964a-dfc24992731f.png)

Thanks,