### PR TITLE
Measure performance by logging map views

### DIFF
--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -439,8 +439,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/roblabs/mapview-log-extensions.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.78.31415;
 			};
 		};
 		D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		117741E3255A2D5200D4866F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741E2255A2D5200D4866F /* MapView.swift */; };
 		B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5270A22DC16E59A33EA1537 /* Pods_Amazon_Location_Service_Demo.framework */; };
 		D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF525C3412500F63D73 /* Mapbox */; };
+		D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */ = {isa = PBXBuildFile; productRef = D7D9C047264494C90053C1AD /* MetalANGLE */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 			files = (
 				D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */,
 				B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */,
+				D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,6 +123,7 @@
 			name = "Amazon Location Service Demo";
 			packageProductDependencies = (
 				D7CB7CF525C3412500F63D73 /* Mapbox */,
+				D7D9C047264494C90053C1AD /* MetalANGLE */,
 			);
 			productName = "Amazon Location Service Demo";
 			productReference = 117741C7255A216600D4866F /* Amazon Location Service Demo.app */;
@@ -431,6 +434,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
 			productName = Mapbox;
+		};
+		D7D9C047264494C90053C1AD /* MetalANGLE */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;
+			productName = MetalANGLE;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 /* Begin XCRemoteSwiftPackageReference section */
 		D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
+			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
 				kind = exactVersion;
 				version = "5.12.0-pre.1";

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -420,8 +420,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maptiler/maplibre-gl-native-distribution";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.11.0;
+				kind = exactVersion;
+				version = "5.12.0-pre.1";
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		117741E0255A2B9200D4866F /* AWSSignatureV4Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741DF255A2B9200D4866F /* AWSSignatureV4Delegate.swift */; };
 		117741E3255A2D5200D4866F /* MapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117741E2255A2D5200D4866F /* MapView.swift */; };
 		B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5270A22DC16E59A33EA1537 /* Pods_Amazon_Location_Service_Demo.framework */; };
+		D7BE8BB0267833BC00044977 /* MapView OSLog Extensions in Frameworks */ = {isa = PBXBuildFile; productRef = D7BE8BAF267833BC00044977 /* MapView OSLog Extensions */; };
 		D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */ = {isa = PBXBuildFile; productRef = D7CB7CF525C3412500F63D73 /* Mapbox */; };
 		D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */ = {isa = PBXBuildFile; productRef = D7D9C047264494C90053C1AD /* MetalANGLE */; };
 /* End PBXBuildFile section */
@@ -38,6 +39,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D7CB7CF625C3412500F63D73 /* Mapbox in Frameworks */,
+				D7BE8BB0267833BC00044977 /* MapView OSLog Extensions in Frameworks */,
 				B1BDC68445B18AD800482856 /* Pods_Amazon_Location_Service_Demo.framework in Frameworks */,
 				D7D9C048264494C90053C1AD /* MetalANGLE in Frameworks */,
 			);
@@ -49,6 +51,7 @@
 		117741BE255A216600D4866F = {
 			isa = PBXGroup;
 			children = (
+				D7D27A61267125EF00217CFA /* Packages */,
 				117741C9255A216600D4866F /* Amazon Location Service Demo */,
 				117741C8255A216600D4866F /* Products */,
 				5628456AD5D23C7EE0DCDC29 /* Pods */,
@@ -95,6 +98,13 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		D7D27A61267125EF00217CFA /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 		F0ABBB147FDED617C4A81D04 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -124,6 +134,7 @@
 			packageProductDependencies = (
 				D7CB7CF525C3412500F63D73 /* Mapbox */,
 				D7D9C047264494C90053C1AD /* MetalANGLE */,
+				D7BE8BAF267833BC00044977 /* MapView OSLog Extensions */,
 			);
 			productName = "Amazon Location Service Demo";
 			productReference = 117741C7255A216600D4866F /* Amazon Location Service Demo.app */;
@@ -154,6 +165,7 @@
 			mainGroup = 117741BE255A216600D4866F;
 			packageReferences = (
 				D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */,
+				D7BE8BAE267833BC00044977 /* XCRemoteSwiftPackageReference "mapview-log-extensions" */,
 			);
 			productRefGroup = 117741C8255A216600D4866F /* Products */;
 			projectDirPath = "";
@@ -356,6 +368,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Amazon Location Service Demo/Preview Content\"";
 				DEVELOPMENT_TEAM = SVHUM2DP35;
 				ENABLE_PREVIEWS = YES;
@@ -365,6 +378,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1;
 				PRODUCT_BUNDLE_IDENTIFIER = "aws.location.Amazon-Location-Service-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -379,6 +393,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Amazon Location Service Demo/Preview Content\"";
 				DEVELOPMENT_TEAM = SVHUM2DP35;
 				ENABLE_PREVIEWS = YES;
@@ -388,6 +403,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				MARKETING_VERSION = 1;
 				PRODUCT_BUNDLE_IDENTIFIER = "aws.location.Amazon-Location-Service-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -419,6 +435,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		D7BE8BAE267833BC00044977 /* XCRemoteSwiftPackageReference "mapview-log-extensions" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/roblabs/mapview-log-extensions.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
@@ -430,6 +454,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		D7BE8BAF267833BC00044977 /* MapView OSLog Extensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D7BE8BAE267833BC00044977 /* XCRemoteSwiftPackageReference "mapview-log-extensions" */;
+			productName = "MapView OSLog Extensions";
+		};
 		D7CB7CF525C3412500F63D73 /* Mapbox */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D7CB7CF225C3412500F63D73 /* XCRemoteSwiftPackageReference "maplibre-gl-native-distribution" */;

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "MapView OSLog Extensions",
         "repositoryURL": "https://github.com/roblabs/mapview-log-extensions.git",
         "state": {
-          "branch": "main",
-          "revision": "d40a22c748a97bcc78a1435343d0157922448819",
-          "version": null
+          "branch": null,
+          "revision": "a30606ebbaaa1e82234a6d055bcd718a459fb3c2",
+          "version": "2.78.31415"
         }
       }
     ]

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "f79911a42f605cbaa9eb1ee6330b464eac47569d",
           "version": "5.12.0-pre.1"
         }
+      },
+      {
+        "package": "MapView OSLog Extensions",
+        "repositoryURL": "https://github.com/roblabs/mapview-log-extensions.git",
+        "state": {
+          "branch": "main",
+          "revision": "d40a22c748a97bcc78a1435343d0157922448819",
+          "version": null
+        }
       }
     ]
   },

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
-          "revision": "dc28d9ad9e1b5c52cdeab26e2fe1781db4974e9a",
-          "version": "5.11.0"
+          "revision": "f79911a42f605cbaa9eb1ee6330b464eac47569d",
+          "version": "5.12.0-pre.1"
         }
       }
     ]

--- a/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/maplibre-native-ios/Amazon Location Service Demo.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "MapLibre GL Native",
-        "repositoryURL": "https://github.com/maptiler/maplibre-gl-native-distribution",
+        "repositoryURL": "https://github.com/maplibre/maplibre-gl-native-distribution",
         "state": {
           "branch": null,
           "revision": "f79911a42f605cbaa9eb1ee6330b464eac47569d",

--- a/maplibre-native-ios/Amazon Location Service Demo/MapView.swift
+++ b/maplibre-native-ios/Amazon Location Service Demo/MapView.swift
@@ -36,6 +36,7 @@ struct MapView: UIViewRepresentable {
 
         _attribution = attribution
         OSLog.mapView(.event, "🗺 regionName: \(regionName), mapName: \(mapName), attribution: \(attribution)")
+        OSLog.mapView(.event, "🖼 frame: \(mapView.frame)")
     }
 
     // MARK: - UIViewRepresentable protocol
@@ -64,7 +65,7 @@ struct MapView: UIViewRepresentable {
         var attribution: Binding<String>
 
         init(_ attribution: Binding<String>) {
-            OSLog.mapView(.event, "Coordinator init")
+            OSLog.mapView(.event, OSLog.mapEvents.initDelegate.description)
             OSLog.mapView(.event, OSLog.mapEvents.WillStartRenderingMap.description)
             OSLog.mapView(.begin, OSLog.mapEvents.WillStartRenderingMap.rawValue)
             OSLog.mapView(.begin, OSLog.mapEvents.DidFinishLoadingStyle.rawValue)

--- a/maplibre-native-ios/Amazon Location Service Demo/MapView.swift
+++ b/maplibre-native-ios/Amazon Location Service Demo/MapView.swift
@@ -4,23 +4,29 @@
 import AWSCore
 import Mapbox
 import SwiftUI
+import OSLog
+import MapViewOSLogExtensions
 
 struct MapView: UIViewRepresentable {
     @Binding var attribution: String
 
     private let mapView: MGLMapView
     private let signingDelegate: MGLOfflineStorageDelegate
+    var oslog = OSLog(subsystem: OSLog.subsystemMapview, category: OSLog.categoryMapview)
 
     init(attribution: Binding<String>) {
+        OSLog.mapView(.event, "🎬 MapView init()")
         let regionName = Bundle.main.object(forInfoDictionaryKey: "AWSRegion") as! String
         let identityPoolId = Bundle.main.object(forInfoDictionaryKey: "IdentityPoolId") as! String
         let mapName = Bundle.main.object(forInfoDictionaryKey: "MapName") as! String
 
         let region = (regionName as NSString).aws_regionTypeValue()
 
+        OSLog.mapView(.event, "✍️ AWSSignatureV4Delegate")
         // MGLOfflineStorage doesn't take ownership, so this needs to be a member here
         signingDelegate = AWSSignatureV4Delegate(region: region, identityPoolId: identityPoolId)
 
+        OSLog.mapView(.event, "✍️ signingDelegate")
         // register a delegate that will handle SigV4 signing
         MGLOfflineStorage.shared.delegate = signingDelegate
 
@@ -29,6 +35,7 @@ struct MapView: UIViewRepresentable {
             styleURL: URL(string: "https://maps.geo.\(regionName).amazonaws.com/maps/v0/maps/\(mapName)/style-descriptor"))
 
         _attribution = attribution
+        OSLog.mapView(.event, "🗺 regionName: \(regionName), mapName: \(mapName), attribution: \(attribution)")
     }
 
     // MARK: - UIViewRepresentable protocol
@@ -38,6 +45,7 @@ struct MapView: UIViewRepresentable {
     }
 
     func makeUIView(context: UIViewRepresentableContext<MapView>) -> MGLMapView {
+        OSLog.mapView(.event)
         mapView.delegate = context.coordinator
 
         mapView.logoView.isHidden = true
@@ -46,21 +54,68 @@ struct MapView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: MGLMapView, context: UIViewRepresentableContext<MapView>) {
+        OSLog.mapView(.event)
     }
 
     // MARK: - MGLMapViewDelegate
 
     class Coordinator: NSObject, MGLMapViewDelegate {
+        var oslog = OSLog(subsystem: OSLog.subsystemMapview, category: OSLog.categoryMapview)
         var attribution: Binding<String>
 
         init(_ attribution: Binding<String>) {
+            OSLog.mapView(.event, "Coordinator init")
+            OSLog.mapView(.event, OSLog.mapEvents.WillStartRenderingMap.description)
+            OSLog.mapView(.begin, OSLog.mapEvents.WillStartRenderingMap.rawValue)
+            OSLog.mapView(.begin, OSLog.mapEvents.DidFinishLoadingStyle.rawValue)
+            OSLog.mapView(.begin, OSLog.mapEvents.DidFinishRenderingMap.rawValue)
+            OSLog.mapView(.begin, OSLog.mapEvents.DidFinishLoadingMap.rawValue)
+            OSLog.mapView(.begin, OSLog.mapEvents.DidBecomeIdle.rawValue)
             self.attribution = attribution
         }
 
         func mapView(_ mapView: MGLMapView, didFinishLoading style: MGLStyle) {
+            OSLog.mapView(.event, OSLog.mapEvents.DidFinishLoadingStyle.rawValue)
+            OSLog.mapView(.end, OSLog.mapEvents.DidFinishLoadingStyle.rawValue)
             let source = style.sources.first as? MGLVectorTileSource
             let attribution = source?.attributionInfos.first
             self.attribution.wrappedValue = attribution?.title.string ?? ""
+        }
+        
+        // MARK: func mapView Delegates
+        func mapViewWillStartLoadingMap(_ mapView: MGLMapView) {
+            os_signpost(.event, log: oslog, name: "mapViewWillStartLoadingMap")
+            OSLog.mapView(.event, OSLog.mapEvents.WillStartLoadingMap.rawValue)
+        }
+
+        func mapViewWillStartRenderingMap(_ mapView: MGLMapView) {
+            OSLog.mapView(.end, OSLog.mapEvents.WillStartRenderingMap.rawValue)
+            OSLog.mapView(.event, OSLog.mapEvents.WillStartRenderingMap_to_DidBecomeIdle.rawValue)
+            OSLog.mapView(.begin, OSLog.mapEvents.WillStartRenderingMap_to_DidBecomeIdle.rawValue)
+        }
+
+        func mapViewWillStartRenderingFrame(_ mapView: MGLMapView) {
+        }
+        
+        func mapViewDidFinishRenderingMap(_ mapView: MGLMapView, fullyRendered: Bool) {
+            OSLog.mapView(.event, OSLog.mapEvents.DidFinishRenderingMap.rawValue)
+            OSLog.mapView(.end, OSLog.mapEvents.DidFinishRenderingMap.rawValue)
+        }
+
+        func mapViewDidFinishLoadingMap(_ mapView: MGLMapView) {
+            OSLog.mapView(.event, OSLog.mapEvents.DidFinishLoadingMap.rawValue)
+            OSLog.mapView(.end, OSLog.mapEvents.DidFinishLoadingMap.rawValue)
+        }
+
+        func mapViewDidBecomeIdle(_ mapView: MGLMapView) {
+            
+            OSLog.mapView(.event, OSLog.mapEvents.DidBecomeIdle.rawValue)
+            OSLog.mapView(.end, OSLog.mapEvents.DidBecomeIdle.rawValue)
+            OSLog.mapView(.end, OSLog.mapEvents.WillStartRenderingMap_to_DidBecomeIdle.rawValue)
+        }
+        
+        func mapViewRegionIsChanging(_ mapView: MGLMapView) {
+            OSLog.mapView(.event, OSLog.mapEvents.RegionIsChanging.rawValue)
         }
     }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

---

The branch of Amazon Location Samples, `roblabs/measure-performance`, is designed to measure visual performance by logging when certain map view events occur.  How to instrument logs specifically for map views is detailed at the repo [roblabs/mapview-log-extensions](https://github.com/roblabs/mapview-log-extensions). 

This PR will stay as a draft, so please grab the branch or review the MapView OSLog extensions repo if you are interested in measuring performance on other projects.

*Details*
Measuring performance is accomplished by adding logging in key places in the AWS iOS sample, and then inspecting in Instruments.  

*Data Sample*
It can be shown that the MapView was initialized at time 0.404 seconds.  The event `DidFinishLoadingMap` occurred at 1.179 seconds.  This data is measuring performance from the Metal branch of MapLibre running on an iPhone SE, iOS 14.6.  

```csv
Timestamp,Thread,Message	
00:00.404.505,Amazon Location Service Demo,🎬 MapView init(), init(attribution:), line 18
00:00.404.812,Amazon Location Service Demo,✍️ AWSSignatureV4Delegate, init(attribution:), line 26
00:00.424.134,Amazon Location Service Demo,✍️ signingDelegate, init(attribution:), line 30
00:00.478.578,Amazon Location Service Demo,🗺 regionName: us-east-1, mapName: EsriDarkGrayCanvas, attribution: Binding<String>(transaction: SwiftUI.Transaction(plist: []), location: SwiftUI.StoredLocation<Swift.String>, _value: ""), init(attribution:), line 39
00:00.479.532,Amazon Location Service Demo,Coordinator init, init(_:), line 70
00:00.479.620,Amazon Location Service Demo,🦮1. WillStartRenderingMap, init(_:), line 71
00:00.479.877,Amazon Location Service Demo,📍, makeUIView(context:), line 49
00:00.481.566,Amazon Location Service Demo,📍, updateUIView(_:context:), line 60
00:00.498.296,Amazon Location Service Demo,🦮11. WillStartRendering has finished, now set timer to DidBecomeIdle, mapViewWillStartRenderingMap(_:), line 97
00:00.535.069,Amazon Location Service Demo,🦮2. DidFinishLoadingStyle, mapView(_:didFinishLoading:), line 81
00:01.179.562,Amazon Location Service Demo,🦮3. DidFinishRenderingMap, mapViewDidFinishRenderingMap(_:fullyRendered:), line 105
00:01.179.718,Amazon Location Service Demo,🦮4. DidFinishLoadingMap, mapViewDidFinishLoadingMap(_:), line 110
00:01.298.494,Amazon Location Service Demo,🦮5. DidBecomeIdle, mapViewDidBecomeIdle(_:), line 116
00:01.466.416,Amazon Location Service Demo,🦮5. DidBecomeIdle, mapViewDidBecomeIdle(_:), line 116
00:02.086.301,Amazon Location Service Demo,🦮5. DidBecomeIdle, mapViewDidBecomeIdle(_:), line 116
00:02.170.108,Amazon Location Service Demo,🦮5. DidBecomeIdle, mapViewDidBecomeIdle(_:), line 116
```