### PR TITLE
UDFs for Amazon Athena

### DIFF
--- a/athena-udfs/.gitignore
+++ b/athena-udfs/.gitignore
@@ -1,0 +1,8 @@
+target/
+packaged.yaml
+.classpath
+.env
+.envrc
+.project
+.settings/
+.vscode/

--- a/athena-udfs/LICENSE
+++ b/athena-udfs/LICENSE
@@ -1,0 +1,14 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/athena-udfs/README.md
+++ b/athena-udfs/README.md
@@ -1,0 +1,116 @@
+# Amazon Location Athena UDFs
+
+This is a set of _Federated Scalar Batch Functions_ for [Amazon Location Service](https://aws.amazon.com/location/) [Amazon Athena](https://aws.amazon.com/athena/) using the [Athena Query Federation SDK](https://github.com/awslabs/aws-athena-query-federation). These User-Defined Functions (UDFs) allow you to geocode and reverse geocode data accessible to Athena from the comfort of SQL.
+
+## Deploying
+
+These UDFs can be [deployed into your account using the AWS Serverless Application Repository](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-west-2:104110588769:applications~AmazonLocationUDFs) (this is a temporary link, available in `us-west-2` only).
+
+At present, this application requires an existing Amazon Location [Place Index](https://docs.aws.amazon.com/location-places/latest/APIReference/API_CreatePlaceIndex.html) resource, configured with `IntendedUse: "Storage"` to comply with [AWS Service Terms](https://aws.amazon.com/service-terms/) for Amazon Location. The name of this resource is provided to UDF implementation via the `PLACE_INDEX_NAME` environment variable.
+
+## Querying
+
+### `search_place_index_for_text`
+
+The following SQL statement demonstrates how to convert textual addresses into coordinates using [`SearchPlaceIndexForText`](https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html). In addition to returning a position, it will decompose the resulting address into components.
+
+```sql
+USING 
+-- use alternate function signatures shown below to provide additional parameters
+EXTERNAL FUNCTION search_place_index_for_text(input VARCHAR)
+  RETURNS ROW(
+    label VARCHAR,
+    address_number VARCHAR,
+    street VARCHAR,
+    municipality VARCHAR,
+    postal_code VARCHAR,
+    sub_region VARCHAR,
+    region VARCHAR,
+    country VARCHAR,
+    geom VARCHAR)
+  LAMBDA 'amazon_location' -- change this if neccessary to reflect LambdaFunctionName
+WITH addresses AS (
+  -- substitute data from an Athena table here
+  SELECT * FROM (VALUES '410 Terry Ave N, Seattle, WA') AS addresses(address)
+), rsp AS (
+  SELECT search_place_index_for_text(address) result
+  FROM addresses
+)
+SELECT
+  result.label,
+  result.address_number,
+  result.street,
+  result.municipality,
+  result.postal_code,
+  result.sub_region,
+  result.region,
+  result.country,
+  ST_GeometryFromText(result.geom) geom
+FROM rsp
+```
+
+Alternate function definitions can be used to provide additional [`SearchPlaceIndexForText`](https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html) parameters:
+
+```sql
+EXTERNAL FUNCTION search_place_index_for_text(input VARCHAR, bias_position_x DOUBLE, bias_position_y DOUBLE)
+EXTERNAL FUNCTION search_place_index_for_text(input VARCHAR, bias_position_x DOUBLE, bias_position_y DOUBLE, countries ARRAY(VARCHAR))
+EXTERNAL FUNCTION search_place_index_for_text(input VARCHAR, filter_min_x DOUBLE, filter_min_y DOUBLE, filter_max_x DOUBLE, filter_max_y DOUBLE)
+EXTERNAL FUNCTION search_place_index_for_text(input VARCHAR, filter_min_x DOUBLE, filter_min_y DOUBLE, filter_max_x DOUBLE, filter_max_y DOUBLE, countries ARRAY(VARCHAR))
+```
+
+### `search_place_index_for_position`
+
+The following SQL statement demonstrates how to convert coordinates into addresses using [`SearchPlaceIndexForPosition`](https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html).
+
+```sql
+USING 
+EXTERNAL FUNCTION search_place_index_for_position(x DOUBLE, y DOUBLE)
+  RETURNS ROW(
+    label VARCHAR,
+    address_number VARCHAR,
+    street VARCHAR,
+    municipality VARCHAR,
+    postal_code VARCHAR,
+    sub_region VARCHAR,
+    region VARCHAR,
+    country VARCHAR,
+    geom VARCHAR)
+  LAMBDA 'amazon_location' -- change this if neccessary to reflect LambdaFunctionName
+WITH positions AS (
+  -- substitute data from an Athena table here
+  SELECT * FROM (VALUES ROW(-122.46729, 37.80575)) AS positions(x, y)
+), rsp AS (
+  SELECT search_place_index_for_position(x, y) result
+  FROM positions
+)
+SELECT
+  result.label,
+  result.address_number,
+  result.street,
+  result.municipality,
+  result.postal_code,
+  result.sub_region,
+  result.region,
+  result.country,
+  ST_GeometryFromText(result.geom) geom
+FROM rsp
+```
+
+## Development / Publishing
+
+To publish your own adaptions to the Serverless Application Repository as a private application, run [`publish.sh`](https://github.com/awslabs/aws-athena-query-federation/blob/master/tools/publish.sh) (part of the [`aws-athena-query-federation`](https://github.com/awslabs/aws-athena-query-federation) repository):
+
+```bash
+aws s3 mb s3://<bucket> --region <region> # create a bucket if necessary
+/path/to/aws-athena-query-federation/tools/publish.sh <bucket> amazon-location-udfs <region>
+```
+
+Once this runs successfully, you'll be able to view the (private) Serverless Application Repository entry for this application and deploy it.
+
+## Security
+
+See [CONTRIBUTING](../CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This library is licensed under the MIT-0 License.

--- a/athena-udfs/amazon-location-udfs.yaml
+++ b/athena-udfs/amazon-location-udfs.yaml
@@ -1,0 +1,87 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+Transform: AWS::Serverless-2016-10-31
+Metadata:
+  'AWS::ServerlessRepo::Application':
+    Name: AmazonLocationUDFs
+    Description: This connector enables Amazon Athena to call Amazon Location APIs with user-defined functions.
+    Author: Seth Fitzsimmons
+    SpdxLicenseId: MIT-0
+    LicenseUrl: LICENSE
+    ReadmeUrl: README.md
+    Labels:
+      - athena-federation
+      - amazon-location
+    HomePageUrl: https://github.com/aws-samples/amazon-location-samples/tree/main/athena-udfs
+    SemanticVersion: 0.1.0
+    SourceCodeUrl: https://github.com/aws-samples/amazon-location-samples/tree/main/athena-udfs
+Parameters:
+  # Until SAR supports the creation of Amazon Location resources, this resource needs to exist ahead of time
+  PlaceIndex:
+    Description: The name of an existing Amazon Location Place Index resource, configured with IntendedUse=Storage.
+    Type: String
+    AllowedPattern: ^[-._\w]{1,100}$
+  # DataSource:
+  #   Description: The data source to use when geocoding
+  #   Type: String
+  #   Default: Esri
+  #   AllowedValues:
+  #     - Esri
+  #     - Here
+  ReservedConcurrentExecutions:
+    Description: Lambda concurrency. More is not necessarily better, as functions may be rate-limited by Amazon Location.
+    Type: Number
+    Default: 10
+  LambdaFunctionName:
+    Description: The name you will give to Lambda function which executes your UDFs.
+    Default: amazon_location
+    Type: String
+    AllowedPattern: ^[a-z0-9-_]{1,64}$
+  LambdaTimeout:
+    Description: Maximum Lambda invocation runtime in seconds (1 - 900); UDF calls are handled sequentially by a shared set of invocations.
+    Default: 900
+    Type: Number
+  LambdaMemory:
+    Description: Lambda memory in MB (128 - 10240).
+    Default: 512
+    Type: Number
+Resources:
+  # PlaceIndex:
+  #   Type: AWS::Location::PlaceIndex
+  #   Properties:
+  #     DataSource: !Ref DataSource
+  #     DataSourceConfiguration:
+  #       IntendedUse: Storage
+  #     Description: Place index for use by Amazon Athena
+  #     IndexName:
+  #       Fn::Sub: ${AWS::StackName}
+  #     PricingPlan: RequestBasedUsage
+  ConnectorConfig:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Ref LambdaFunctionName
+      Handler: aws.samples.amazonlocation.AmazonLocationUDFHandler
+      ReservedConcurrentExecutions: !Ref ReservedConcurrentExecutions
+      CodeUri: ./target/athena-udfs-1.0-SNAPSHOT.jar
+      Description: This connector enables Amazon Athena to call Amazon Location APIs as UDFs.
+      Runtime: java11
+      Timeout: !Ref LambdaTimeout
+      MemorySize: !Ref LambdaMemory
+      Environment:
+        Variables:
+          PLACE_INDEX_NAME:
+            Ref: PlaceIndex
+      Policies:
+        - Statement:
+            - Action:
+                - geo:SearchPlaceIndex*
+              Effect: Allow
+              Resource:
+                - !Sub "arn:${AWS::Partition}:geo:${AWS::Region}:${AWS::AccountId}:place-index/${PlaceIndex}"
+      # Policies:
+      #   - Statement:
+      #       - Action:
+      #           - geo:SearchPlaceIndex*
+      #         Effect: Allow
+      #         Resource:
+      #           - Fn::GetAtt: [PlaceIndex, Arn]

--- a/athena-udfs/pom.xml
+++ b/athena-udfs/pom.xml
@@ -1,0 +1,72 @@
+<!-- Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. -->
+<!-- SPDX-License-Identifier: MIT-0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>aws.samples.amazon-location</groupId>
+  <artifactId>athena-udfs</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>athena-udfs</name>
+
+  <properties>
+    <aws-athena-federation-sdk.version>2021.37.1</aws-athena-federation-sdk.version>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-bom</artifactId>
+        <version>1.12.70</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-athena-federation-sdk</artifactId>
+      <version>${aws-athena-federation-sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-location</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <configuration>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/athena-udfs/src/main/java/aws/samples/amazonlocation/AmazonLocationUDFHandler.java
+++ b/athena-udfs/src/main/java/aws/samples/amazonlocation/AmazonLocationUDFHandler.java
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+package aws.samples.amazonlocation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.athena.connector.lambda.exceptions.FederationThrottleException;
+import com.amazonaws.athena.connector.lambda.handlers.UserDefinedFunctionHandler;
+import com.amazonaws.services.location.AmazonLocation;
+import com.amazonaws.services.location.AmazonLocationClient;
+import com.amazonaws.services.location.model.Place;
+import com.amazonaws.services.location.model.PlaceGeometry;
+import com.amazonaws.services.location.model.SearchPlaceIndexForPositionRequest;
+import com.amazonaws.services.location.model.SearchPlaceIndexForTextRequest;
+import com.amazonaws.services.location.model.ThrottlingException;
+
+public class AmazonLocationUDFHandler extends UserDefinedFunctionHandler {
+    private static final String PLACE_INDEX_NAME = System.getenv("PLACE_INDEX_NAME");
+    private final AmazonLocation client = AmazonLocationClient.builder()
+            .withClientConfiguration(new ClientConfiguration()
+                    // push retries onto Athena by disabling them here
+                    .withMaxErrorRetry(0)
+                    // identify these calls as coming via Athena
+                    .withUserAgentSuffix("Amazon Athena"))
+            .build();
+
+    public AmazonLocationUDFHandler() {
+        super("AmazonLocation");
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForPosition API.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param x X/longitude coordinate.
+     * @param y Y/latitude coordinate.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_position(Double x, Double y) {
+        try {
+            return client.searchPlaceIndexForPosition(buildPositionRequest().withPosition(x, y)).getResults().stream()
+                    .map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForText API.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param text Query text.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_text(String text) {
+        try {
+            return client.searchPlaceIndexForText(buildTextRequest().withText(text)).getResults().stream()
+                    .map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForText API with a bias
+     * position.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param text          Query text.
+     * @param biasPositionX Bias position x-coordinate.
+     * @param biasPositionY Bias position y-coordinate.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_text(String text, Double biasPositionX, Double biasPositionY) {
+        try {
+            return client
+                    .searchPlaceIndexForText(
+                            buildTextRequest().withText(text).withBiasPosition(biasPositionX, biasPositionY))
+                    .getResults().stream().map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForText API with a bias
+     * position and a country filter.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param text          Query text.
+     * @param biasPositionX Bias position x-coordinate.
+     * @param biasPositionY Bias position y-coordinate.
+     * @param countryFilter List of 3-digit ISO country codes.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_text(String text, Double biasPositionX, Double biasPositionY,
+            List<String> countryFilter) {
+        try {
+            return client
+                    .searchPlaceIndexForText(buildTextRequest().withText(text)
+                            .withBiasPosition(biasPositionX, biasPositionY).withFilterCountries(countryFilter))
+                    .getResults().stream().map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForText API with a bounding
+     * box filter.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param text        Query text.
+     * @param filterBBoxW Minimum x-coordinate for bounding box filter.
+     * @param filterBBoxS Minimum y-coordinate for bounding box filter.
+     * @param filterBBoxE Maximum x-coordinate for bounding box filter.
+     * @param filterBBoxN Maximum y-coordinate for bounding box filter.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_text(String text, Double filterBBoxW, Double filterBBoxS,
+            Double filterBBoxE, Double filterBBoxN) {
+        try {
+            return client
+                    .searchPlaceIndexForText(buildTextRequest().withText(text).withFilterBBox(filterBBoxW, filterBBoxS,
+                            filterBBoxE, filterBBoxN))
+                    .getResults().stream().map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Call Amazon Location Service's SearchPlaceIndexForText API with a bounding
+     * box filter.
+     *
+     * Note: UDF names must be lowercase.
+     *
+     * @param text          Query text.
+     * @param filterBBoxW   Minimum x-coordinate for bounding box filter.
+     * @param filterBBoxS   Minimum y-coordinate for bounding box filter.
+     * @param filterBBoxE   Maximum x-coordinate for bounding box filter.
+     * @param filterBBoxN   Maximum y-coordinate for bounding box filter.
+     * @param countryFilter List of 3-digit ISO country codes.
+     * @return First result.
+     */
+    public Map<String, Object> search_place_index_for_text(String text, Double filterBBoxW, Double filterBBoxS,
+            Double filterBBoxE, Double filterBBoxN, List<String> countryFilter) {
+        try {
+            return client
+                    .searchPlaceIndexForText(buildTextRequest().withText(text)
+                            .withFilterBBox(filterBBoxW, filterBBoxS, filterBBoxE, filterBBoxN)
+                            .withFilterCountries(countryFilter))
+                    .getResults().stream().map(r -> r.getPlace()).map(place -> toMap(place)).findFirst().orElse(null);
+        } catch (ThrottlingException e) {
+            throw new FederationThrottleException("Throttled by upstream service", e);
+        }
+    }
+
+    /**
+     * Create a pre-configured SearchPlaceIndexForPositionRequest.
+     *
+     * @return Request initialized with the index name and number of max results
+     *         populated.
+     */
+    private SearchPlaceIndexForPositionRequest buildPositionRequest() {
+        return new SearchPlaceIndexForPositionRequest().withIndexName(PLACE_INDEX_NAME).withMaxResults(1);
+    }
+
+    /**
+     * Create a pre-configured SearchPlaceIndexForTextRequest.
+     *
+     * @return Request initialized with the index name and number of max results
+     *         populated.
+     */
+    private SearchPlaceIndexForTextRequest buildTextRequest() {
+        return new SearchPlaceIndexForTextRequest().withIndexName(PLACE_INDEX_NAME).withMaxResults(1);
+    }
+
+    /**
+     * Convert a geometry to well-known-text (WKT).
+     *
+     * @param geometry PlaceGeometry to convert.
+     * @return WKT-formatted geometry.
+     */
+    private String toWKT(PlaceGeometry geometry) {
+        return String.format("POINT(%s)",
+                geometry.getPoint().stream().map(c -> c.toString()).collect(Collectors.joining(" ")));
+    }
+
+    /**
+     * Convert a Place to a Map<String, Object>, suitable for returning to Athena.
+     *
+     * @param place Place to convert.
+     * @return Map of place properties.
+     */
+    private Map<String, Object> toMap(Place place) {
+        return Map.of("label", Optional.ofNullable(place.getLabel()).orElse(""), "address_number",
+                Optional.ofNullable(place.getAddressNumber()).orElse(""), "street",
+                Optional.ofNullable(place.getStreet()).orElse(""), "municipality",
+                Optional.ofNullable(place.getMunicipality()).orElse(""), "postal_code",
+                Optional.ofNullable(place.getPostalCode()).orElse(""), "sub_region",
+                Optional.ofNullable(place.getSubRegion()).orElse(""), "region",
+                Optional.ofNullable(place.getRegion()).orElse(""), "country",
+                Optional.ofNullable(place.getCountry()).orElse(""), "geom", toWKT(place.getGeometry()));
+    }
+}


### PR DESCRIPTION
Call [`SearchPlaceIndexForText`](https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForText.html) and [`SearchPlaceIndexForPosition`](https://docs.aws.amazon.com/location-places/latest/APIReference/API_SearchPlaceIndexForPosition.html) from Athena. The solution is deployable from the AWS Serverless Application Repository.

## TODO

- [ ] Create a PlaceIndex resource as part of the CFn template (pending the ability to create Amazon Location resources as part of SAR applications)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
