### PR TITLE
Use the correct Credential type for TypeScript

### DIFF
--- a/amazon-location-helpers/index.d.ts
+++ b/amazon-location-helpers/index.d.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
-import { Credentials } from "@aws-sdk/client-cognito-identity";
+import { Credentials } from "@aws-sdk/types";
 import mapboxgl from "maplibre-gl";
 
 interface Config {

--- a/amazon-location-helpers/package-lock.json
+++ b/amazon-location-helpers/package-lock.json
@@ -5,12 +5,14 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "amazon-location-helpers",
       "version": "1.1.0",
       "license": "MIT-0",
       "dependencies": {
         "@aws-amplify/core": "^4.0.3",
         "@aws-sdk/client-cognito-identity": "^3.6.1",
         "@aws-sdk/credential-provider-cognito-identity": "^3.6.1",
+        "@aws-sdk/types": "^3.36.0",
         "@types/maplibre-gl": "^1.13.1"
       },
       "devDependencies": {
@@ -32,6 +34,14 @@
       },
       "peerDependencies": {
         "@react-native-async-storage/async-storage": "^1.13.0"
+      }
+    },
+    "node_modules/@aws-amplify/core/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -117,6 +127,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/abort-controller/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cognito-identity": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.6.1.tgz",
@@ -173,6 +191,14 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
@@ -204,6 +230,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/config-resolver/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.6.1.tgz",
@@ -214,6 +248,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -231,6 +273,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-env/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-imds": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.6.1.tgz",
@@ -240,6 +290,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -254,6 +312,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -276,6 +342,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.6.1.tgz",
@@ -287,6 +361,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -303,6 +385,14 @@
         "tslib": "^1.8.0"
       }
     },
+    "node_modules/@aws-sdk/fetch-http-handler/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/hash-node": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.6.1.tgz",
@@ -316,6 +406,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/hash-node/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/invalid-dependency": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.6.1.tgz",
@@ -323,6 +421,14 @@
       "dependencies": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/@aws-sdk/is-array-buffer": {
@@ -349,6 +455,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-content-length/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.6.1.tgz",
@@ -362,6 +476,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-host-header/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.6.1.tgz",
@@ -370,6 +492,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -390,6 +520,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-serde": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.6.1.tgz",
@@ -398,6 +536,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -412,6 +558,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -440,6 +594,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/node-config-provider": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.6.1.tgz",
@@ -450,6 +612,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -469,6 +639,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/node-http-handler/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/property-provider": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.6.1.tgz",
@@ -481,6 +659,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/property-provider/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/protocol-http": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.6.1.tgz",
@@ -489,6 +675,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -506,6 +700,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/querystring-builder/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/querystring-parser": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.6.1.tgz",
@@ -514,6 +716,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -552,6 +762,14 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/smithy-client": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.6.1.tgz",
@@ -565,10 +783,18 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@aws-sdk/types": {
+    "node_modules/@aws-sdk/smithy-client/node_modules/@aws-sdk/types": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
       "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.36.0.tgz",
+      "integrity": "sha512-OeaTDZqo4OfGahgsZF2viOWxSSNColEUf8RbKAWNlke3nkMu3JW8kkft1Qte6jvoQxZ3jOQWi33Z4LUxix/V7A==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -593,6 +819,22 @@
         "tslib": "^1.8.0",
         "url": "^0.11.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser-native/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -696,6 +938,14 @@
         "tslib": "^1.8.0"
       }
     },
+    "node_modules/@aws-sdk/util-user-agent-browser/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.6.1.tgz",
@@ -705,6 +955,14 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
       },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node/node_modules/@aws-sdk/types": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g==",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -9602,6 +9860,13 @@
         "@aws-sdk/util-hex-encoding": "3.6.1",
         "universal-cookie": "^4.0.4",
         "zen-observable-ts": "0.8.19"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-crypto/ie11-detection": {
@@ -9685,6 +9950,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/client-cognito-identity": {
@@ -9742,6 +10014,11 @@
             }
           }
         },
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        },
         "@aws-sdk/util-utf8-browser": {
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.6.1.tgz",
@@ -9772,6 +10049,13 @@
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-cognito-identity": {
@@ -9783,6 +10067,13 @@
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-env": {
@@ -9793,6 +10084,13 @@
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-imds": {
@@ -9803,6 +10101,13 @@
         "@aws-sdk/property-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-ini": {
@@ -9814,6 +10119,13 @@
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-node": {
@@ -9829,6 +10141,13 @@
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/credential-provider-process": {
@@ -9841,6 +10160,13 @@
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/fetch-http-handler": {
@@ -9853,6 +10179,13 @@
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-base64-browser": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/hash-node": {
@@ -9863,6 +10196,13 @@
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-buffer-from": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/invalid-dependency": {
@@ -9872,6 +10212,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/is-array-buffer": {
@@ -9890,6 +10237,13 @@
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-host-header": {
@@ -9900,6 +10254,13 @@
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-logger": {
@@ -9909,6 +10270,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-retry": {
@@ -9922,6 +10290,13 @@
         "react-native-get-random-values": "^1.4.0",
         "tslib": "^1.8.0",
         "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-serde": {
@@ -9931,6 +10306,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-signing": {
@@ -9942,6 +10324,13 @@
         "@aws-sdk/signature-v4": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/middleware-stack": {
@@ -9960,6 +10349,13 @@
         "@aws-sdk/protocol-http": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/node-config-provider": {
@@ -9971,6 +10367,13 @@
         "@aws-sdk/shared-ini-file-loader": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/node-http-handler": {
@@ -9983,6 +10386,13 @@
         "@aws-sdk/querystring-builder": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/property-provider": {
@@ -9992,6 +10402,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/protocol-http": {
@@ -10001,6 +10418,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/querystring-builder": {
@@ -10011,6 +10435,13 @@
         "@aws-sdk/types": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/querystring-parser": {
@@ -10020,6 +10451,13 @@
       "requires": {
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/service-error-classification": {
@@ -10045,6 +10483,13 @@
         "@aws-sdk/util-hex-encoding": "3.6.1",
         "@aws-sdk/util-uri-escape": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/smithy-client": {
@@ -10055,12 +10500,19 @@
         "@aws-sdk/middleware-stack": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/types": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
-      "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.36.0.tgz",
+      "integrity": "sha512-OeaTDZqo4OfGahgsZF2viOWxSSNColEUf8RbKAWNlke3nkMu3JW8kkft1Qte6jvoQxZ3jOQWi33Z4LUxix/V7A=="
     },
     "@aws-sdk/url-parser": {
       "version": "3.6.1",
@@ -10070,6 +10522,13 @@
         "@aws-sdk/querystring-parser": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/url-parser-native": {
@@ -10081,6 +10540,13 @@
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0",
         "url": "^0.11.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/util-base64-browser": {
@@ -10164,6 +10630,13 @@
         "@aws-sdk/types": "3.6.1",
         "bowser": "^2.11.0",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/util-user-agent-node": {
@@ -10174,6 +10647,13 @@
         "@aws-sdk/node-config-provider": "3.6.1",
         "@aws-sdk/types": "3.6.1",
         "tslib": "^1.8.0"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.6.1",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.6.1.tgz",
+          "integrity": "sha512-4Dx3eRTrUHLxhFdLJL8zdNGzVsJfAxtxPYYGmIddUkO2Gj3WA1TGjdfG4XN/ClI6e1XonCHafQX3UYO/mgnH3g=="
+        }
       }
     },
     "@aws-sdk/util-utf8-browser": {

--- a/amazon-location-helpers/package.json
+++ b/amazon-location-helpers/package.json
@@ -19,6 +19,7 @@
     "@aws-amplify/core": "^4.0.3",
     "@aws-sdk/client-cognito-identity": "^3.6.1",
     "@aws-sdk/credential-provider-cognito-identity": "^3.6.1",
+    "@aws-sdk/types": "^3.36.0",
     "@types/maplibre-gl": "^1.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The previous `Credentials` type defined PascalCase parameters while the returned value contained camelCase parameters. This fixes bridging to Amplify's `ICredentials` type w/o casting.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
