### PR TITLE
Fix up minor warts

### DIFF
--- a/react-map-gl-amplify/LICENSE
+++ b/react-map-gl-amplify/LICENSE
@@ -1,0 +1,15 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/react-map-gl-amplify/package-lock.json
+++ b/react-map-gl-amplify/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.1.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-amplify/geo": "^1.1.2",
-        "aws-amplify": "^3.4.3",
+        "aws-amplify": "^4.3.2",
         "maplibre-gl": "^1.15.2",
         "maplibre-gl-js-amplify": "^1.1.0",
         "react": "^17.0.1",
@@ -29,12 +28,12 @@
       }
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "4.0.22",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-4.0.22.tgz",
-      "integrity": "sha512-pbj1CedBW35y3rStVv4GtxjNVBMZZoMu0DBj3XOzqeapXn0XFh0LprPGk4Pz3uqaIVQCMN34UNI/a62z04AbTw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.1.0.tgz",
+      "integrity": "sha512-H0CVVRfa3jqA7CK7TqP3G21ydOsqV7XF319H5aU5gdd162PgYUjS+0DIRGAFiM1t18CtU8dPW5BW/xJS3920nQ==",
       "dependencies": {
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -45,63 +44,64 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.3.3.tgz",
-      "integrity": "sha512-4gH7HWQCRARnfDtlDv/YxqQ3p0NMqn52KLarLm4wj0iajfztWZUyC3Yanf9srnseoVVrdkNYHV67zHMkpRBVQg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.20.tgz",
+      "integrity": "sha512-Xdef4zaGYK7UBjclj0BpautE6HExprQqrLwWZq+tYm5FLHRsVIXlvNutWPNEaBfSbJ+bGMHIEFvn7ecC0FYNJA==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "1.3.3",
-        "@aws-amplify/api-rest": "1.2.34"
+        "@aws-amplify/api-graphql": "2.2.9",
+        "@aws-amplify/api-rest": "2.0.20"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.3.3.tgz",
-      "integrity": "sha512-pV+IiQlAgmk6EvIaX0y/sygXS82yeJzft1d/kle9oIA/AP+biTobCF87nweL99A6lXa/Ov1Qf5Sr0PrVNkNmlw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.9.tgz",
+      "integrity": "sha512-ykZTL9h02280/UAWoyrMRSuAxLh+uPDgEPJ9E5lIcmDkaT6E/kx2/hWMQ6jSe3Rky4LT+J4UMTR+ikYMcXr5Aw==",
       "dependencies": {
-        "@aws-amplify/api-rest": "1.2.34",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/pubsub": "3.3.3",
+        "@aws-amplify/api-rest": "2.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/pubsub": "4.1.12",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "1.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.34.tgz",
-      "integrity": "sha512-6mng+VAaj10xcOQsLZqv4QcAXepehBqU7petsUft26l/cJpva5YbtoJJXmjIJ/tcUEzVRGQwKmUSRYLeN06FLg==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.20.tgz",
+      "integrity": "sha512-ah9NcE/b8yz9XZVBuir582IVjnUMC2N7SXJymLOMJO2NaGiMhjhWlojRo5gzm8H2/vit+zJxzxBjhgZ3p+LuMQ==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24",
-        "axios": "0.21.1"
+        "@aws-amplify/core": "4.3.2",
+        "axios": "0.21.4"
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.4.34.tgz",
-      "integrity": "sha512-6Q+QDjb3ljAh3PptLFpdZn1kXOsv1yAwyvBZdaKP8ZRmgj8yT7yeR3a2nczY7HTj9Vhr4DXqI3rB3YYToJemLQ==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.10.tgz",
+      "integrity": "sha512-nub/0uVBVL/EYwbPNrRaoOA0VabX8zmpO5CDiYtt4YDB88SUvA5xYFO+7rJ9r8BGq5SNw3wqyDKSPJscFuzosQ==",
       "dependencies": {
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "amazon-cognito-identity-js": "4.6.3",
-        "crypto-js": "^4.0.0"
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "amazon-cognito-identity-js": "5.2.0",
+        "crypto-js": "^4.1.1"
       }
     },
     "node_modules/@aws-amplify/cache": {
-      "version": "3.1.57",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.57.tgz",
-      "integrity": "sha512-BSizxpLeOwZ3rDSznP+PUTxSvdmlSctyBEp5UFa5/m9KKTr/+RKjP0W2xk2thAS9faFiVaXvocf2B/RDs4GqDg==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.22.tgz",
+      "integrity": "sha512-ZUmPuQzKhIquEaWnf4+nK7qBaylYxdfA5D3GVJ0WmQrjM8OR79OOY1VlyGzry5GWjFSQFpslnbfW3fnrPnP9tQ==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24"
+        "@aws-amplify/core": "4.3.2"
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "3.8.24",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.8.24.tgz",
-      "integrity": "sha512-py/M/UKKYSltTikNDEju3kmwDhmMv+qZ5bouSxRwprLTuwDmLzUcIFerPN2g4cmoF9JictlC/+9D3q5Wz7ha5w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.2.tgz",
+      "integrity": "sha512-JHmAO3IyNoftFP6P2dNWTTs4mKGXcoFYoJQ7ONNWBmJq6RdWG8Ej/flP/42N8rhE7lA6qbY1AGuEl7QglJboDA==",
       "dependencies": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
         "@aws-sdk/client-cognito-identity": "3.6.1",
         "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -111,21 +111,30 @@
       }
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.10.1.tgz",
-      "integrity": "sha512-6t3XygUPDdFbRRrn3kd11+8A30Mh7vzA2zdD+rwc39nZhgb/angmm2bpDSfC5t9tRftv0JBOkAaWOu6nxtLhKw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.8.tgz",
+      "integrity": "sha512-uqHdjGT4hvAYsFA6m91pekYWT/z0D7sCpzjRJrKJB0gLGvCyIrVZTJP65l8+5IAFlnpcu9wrT/Y/EfiMjkkmtg==",
       "dependencies": {
-        "@aws-amplify/api": "3.3.3",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/pubsub": "3.3.3",
-        "amazon-cognito-identity-js": "4.6.3",
+        "@aws-amplify/api": "4.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/pubsub": "4.1.12",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
-        "immer": "8.0.1",
+        "immer": "9.0.6",
         "ulid": "2.3.0",
         "uuid": "3.3.2",
         "zen-observable-ts": "0.8.19",
         "zen-push": "0.2.1"
+      }
+    },
+    "node_modules/@aws-amplify/datastore/node_modules/immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/@aws-amplify/datastore/node_modules/uuid": {
@@ -147,37 +156,22 @@
         "camelcase-keys": "6.2.2"
       }
     },
-    "node_modules/@aws-amplify/geo/node_modules/@aws-amplify/core": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.2.tgz",
-      "integrity": "sha512-JHmAO3IyNoftFP6P2dNWTTs4mKGXcoFYoJQ7ONNWBmJq6RdWG8Ej/flP/42N8rhE7lA6qbY1AGuEl7QglJboDA==",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
-        "@aws-sdk/client-cognito-identity": "3.6.1",
-        "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
-        "@aws-sdk/types": "3.6.1",
-        "@aws-sdk/util-hex-encoding": "3.6.1",
-        "universal-cookie": "^4.0.4",
-        "zen-observable-ts": "0.8.19"
-      }
-    },
     "node_modules/@aws-amplify/interactions": {
-      "version": "3.3.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.3.34.tgz",
-      "integrity": "sha512-152FEwVqtfJ8rDi0VGzqL4CSu44QCiRTHpKyacWMPcxdC6E0DtVdzcNgo94fenpJIQi2LyKuN8UZvK+NnMDENg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.20.tgz",
+      "integrity": "sha512-pC7eYqt0dJgwMg4kili0f2EsIEPWrpnoL4BKONOkeMR9oGwLgS1Vc1jrr7V0ILFQE2dF9bU9xWPZ9TlETQpDpg==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "node_modules/@aws-amplify/predictions": {
-      "version": "3.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.2.34.tgz",
-      "integrity": "sha512-PObKVaW9sq3jnRpY85w6Ns38UItD66R0Yy+HsvcRfNBjIOOQT1bqvEEqLQZad0zP3hBSxnNGvdze4ye3oQZuwg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.20.tgz",
+      "integrity": "sha512-J3Gza1NEtXeuQW1O41gj9bLkUgHIT6BHMcV07y4vAlMuU/DYnK4K9bnYDpKQQTkcByXaBz7A2ab+Hxb9JdYZdQ==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/storage": "3.4.4",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/storage": "4.4.3",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -189,13 +183,13 @@
       }
     },
     "node_modules/@aws-amplify/pubsub": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.3.3.tgz",
-      "integrity": "sha512-j9PwkOjUhGE1cbExVjVfVeR7aMzlwckbP01K6QHPqOccstS/ZVD3W9ifhVCYJho1TTa6NoT7wn2HromesP2frQ==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.12.tgz",
+      "integrity": "sha512-CSEjOLlUaVceTwjfSdwWVWtQnzs0YScPmTwH3fUDdxRatEOOVYBckRhryygXIk/RzsDMCyMYwclxEy0ZtEE+GA==",
       "dependencies": {
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -203,31 +197,31 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.4.4.tgz",
-      "integrity": "sha512-Qwh3G0e1UiqDTMnKgkxpM7BPoL9FozfGc2m1yWGT+VFbmVBZmuQyo1p3ENVgIbghQ/TqLpj447mg0Xfl4bZ3cQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.3.tgz",
+      "integrity": "sha512-K6S8ZbHaXX8qLbL+Jbqx4AsJwBWfQMLSygYdF5Z5eUAAprOG3icwa1Th/y9UaZ1/wJNfzvjRu8VK3ToLlJcCyw==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
         "@aws-sdk/util-format-url": "3.6.1",
-        "axios": "0.21.1",
+        "axios": "0.21.4",
         "events": "^3.1.0",
         "sinon": "^7.5.0"
       }
     },
     "node_modules/@aws-amplify/ui": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.2.tgz",
-      "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.3.tgz",
+      "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "node_modules/@aws-amplify/xr": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.2.34.tgz",
-      "integrity": "sha512-EooROlYAPQ6ty5lB7tRjXiXPtTIMsgDXidKUmNG8UPMbjbSYGQUVWA8TSYc18tJ/zYyiDYHCFH7MzIzv425FNQ==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.20.tgz",
+      "integrity": "sha512-Z3e6NdhkxE7Mu6LFgHOSsjz8aq/BGJ22wPqYg5vRD+dLQgTGCoHm88l8WFWMMensRqTer0+pn8fJWea7/biOcQ==",
       "dependencies": {
-        "@aws-amplify/core": "3.8.24"
+        "@aws-amplify/core": "4.3.2"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -8769,12 +8763,12 @@
       "dev": true
     },
     "node_modules/amazon-cognito-identity-js": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.6.3.tgz",
-      "integrity": "sha512-MPVJfirbdmSGo7l4h7Kbn3ms1eJXT5Xq8ly+mCPPi8yAxaxdg7ouMUUNTqtDykoZxIdDLF/P6F3Zbg3dlGKOWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "dependencies": {
         "buffer": "4.9.2",
-        "crypto-js": "^4.0.0",
+        "crypto-js": "^4.1.1",
         "fast-base64-decode": "^1.0.0",
         "isomorphic-unfetch": "^3.0.0",
         "js-cookie": "^2.2.1"
@@ -9204,22 +9198,23 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.4.3.tgz",
-      "integrity": "sha512-eLWQ+2aLlnpWIK+5OGzlut9z/zZWcxVia4JOYbT3lrIMCsLRUZzqGioBsEg7XCggHSJMXIBkwLMMzuTZK/dQ1w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.2.tgz",
+      "integrity": "sha512-p7et0uQvzQEebEk4yij/93wuozvUxSpufhFBpri5IuU0rQU0qHwb0bWEeIdtf93PrMbQcdeozfA82bSntvteEA==",
       "dependencies": {
-        "@aws-amplify/analytics": "4.0.22",
-        "@aws-amplify/api": "3.3.3",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/datastore": "2.10.1",
-        "@aws-amplify/interactions": "3.3.34",
-        "@aws-amplify/predictions": "3.2.34",
-        "@aws-amplify/pubsub": "3.3.3",
-        "@aws-amplify/storage": "3.4.4",
-        "@aws-amplify/ui": "2.0.2",
-        "@aws-amplify/xr": "2.2.34"
+        "@aws-amplify/analytics": "5.1.0",
+        "@aws-amplify/api": "4.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/datastore": "3.4.8",
+        "@aws-amplify/geo": "1.1.2",
+        "@aws-amplify/interactions": "4.0.20",
+        "@aws-amplify/predictions": "4.0.20",
+        "@aws-amplify/pubsub": "4.1.12",
+        "@aws-amplify/storage": "4.4.3",
+        "@aws-amplify/ui": "2.0.3",
+        "@aws-amplify/xr": "3.0.20"
       }
     },
     "node_modules/axe-core": {
@@ -9232,11 +9227,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -15798,6 +15793,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
       "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -29610,12 +29606,12 @@
   },
   "dependencies": {
     "@aws-amplify/analytics": {
-      "version": "4.0.22",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-4.0.22.tgz",
-      "integrity": "sha512-pbj1CedBW35y3rStVv4GtxjNVBMZZoMu0DBj3XOzqeapXn0XFh0LprPGk4Pz3uqaIVQCMN34UNI/a62z04AbTw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-5.1.0.tgz",
+      "integrity": "sha512-H0CVVRfa3jqA7CK7TqP3G21ydOsqV7XF319H5aU5gdd162PgYUjS+0DIRGAFiM1t18CtU8dPW5BW/xJS3920nQ==",
       "requires": {
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-firehose": "3.6.1",
         "@aws-sdk/client-kinesis": "3.6.1",
         "@aws-sdk/client-personalize-events": "3.6.1",
@@ -29626,63 +29622,64 @@
       }
     },
     "@aws-amplify/api": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-3.3.3.tgz",
-      "integrity": "sha512-4gH7HWQCRARnfDtlDv/YxqQ3p0NMqn52KLarLm4wj0iajfztWZUyC3Yanf9srnseoVVrdkNYHV67zHMkpRBVQg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-4.0.20.tgz",
+      "integrity": "sha512-Xdef4zaGYK7UBjclj0BpautE6HExprQqrLwWZq+tYm5FLHRsVIXlvNutWPNEaBfSbJ+bGMHIEFvn7ecC0FYNJA==",
       "requires": {
-        "@aws-amplify/api-graphql": "1.3.3",
-        "@aws-amplify/api-rest": "1.2.34"
+        "@aws-amplify/api-graphql": "2.2.9",
+        "@aws-amplify/api-rest": "2.0.20"
       }
     },
     "@aws-amplify/api-graphql": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-1.3.3.tgz",
-      "integrity": "sha512-pV+IiQlAgmk6EvIaX0y/sygXS82yeJzft1d/kle9oIA/AP+biTobCF87nweL99A6lXa/Ov1Qf5Sr0PrVNkNmlw==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-2.2.9.tgz",
+      "integrity": "sha512-ykZTL9h02280/UAWoyrMRSuAxLh+uPDgEPJ9E5lIcmDkaT6E/kx2/hWMQ6jSe3Rky4LT+J4UMTR+ikYMcXr5Aw==",
       "requires": {
-        "@aws-amplify/api-rest": "1.2.34",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/pubsub": "3.3.3",
+        "@aws-amplify/api-rest": "2.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/pubsub": "4.1.12",
         "graphql": "14.0.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
       }
     },
     "@aws-amplify/api-rest": {
-      "version": "1.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-1.2.34.tgz",
-      "integrity": "sha512-6mng+VAaj10xcOQsLZqv4QcAXepehBqU7petsUft26l/cJpva5YbtoJJXmjIJ/tcUEzVRGQwKmUSRYLeN06FLg==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-2.0.20.tgz",
+      "integrity": "sha512-ah9NcE/b8yz9XZVBuir582IVjnUMC2N7SXJymLOMJO2NaGiMhjhWlojRo5gzm8H2/vit+zJxzxBjhgZ3p+LuMQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.24",
-        "axios": "0.21.1"
+        "@aws-amplify/core": "4.3.2",
+        "axios": "0.21.4"
       }
     },
     "@aws-amplify/auth": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-3.4.34.tgz",
-      "integrity": "sha512-6Q+QDjb3ljAh3PptLFpdZn1kXOsv1yAwyvBZdaKP8ZRmgj8yT7yeR3a2nczY7HTj9Vhr4DXqI3rB3YYToJemLQ==",
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-4.3.10.tgz",
+      "integrity": "sha512-nub/0uVBVL/EYwbPNrRaoOA0VabX8zmpO5CDiYtt4YDB88SUvA5xYFO+7rJ9r8BGq5SNw3wqyDKSPJscFuzosQ==",
       "requires": {
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "amazon-cognito-identity-js": "4.6.3",
-        "crypto-js": "^4.0.0"
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "amazon-cognito-identity-js": "5.2.0",
+        "crypto-js": "^4.1.1"
       }
     },
     "@aws-amplify/cache": {
-      "version": "3.1.57",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-3.1.57.tgz",
-      "integrity": "sha512-BSizxpLeOwZ3rDSznP+PUTxSvdmlSctyBEp5UFa5/m9KKTr/+RKjP0W2xk2thAS9faFiVaXvocf2B/RDs4GqDg==",
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/cache/-/cache-4.0.22.tgz",
+      "integrity": "sha512-ZUmPuQzKhIquEaWnf4+nK7qBaylYxdfA5D3GVJ0WmQrjM8OR79OOY1VlyGzry5GWjFSQFpslnbfW3fnrPnP9tQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.24"
+        "@aws-amplify/core": "4.3.2"
       }
     },
     "@aws-amplify/core": {
-      "version": "3.8.24",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-3.8.24.tgz",
-      "integrity": "sha512-py/M/UKKYSltTikNDEju3kmwDhmMv+qZ5bouSxRwprLTuwDmLzUcIFerPN2g4cmoF9JictlC/+9D3q5Wz7ha5w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.2.tgz",
+      "integrity": "sha512-JHmAO3IyNoftFP6P2dNWTTs4mKGXcoFYoJQ7ONNWBmJq6RdWG8Ej/flP/42N8rhE7lA6qbY1AGuEl7QglJboDA==",
       "requires": {
         "@aws-crypto/sha256-js": "1.0.0-alpha.0",
+        "@aws-sdk/client-cloudwatch-logs": "3.6.1",
         "@aws-sdk/client-cognito-identity": "3.6.1",
         "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
         "@aws-sdk/types": "3.6.1",
@@ -29692,23 +29689,28 @@
       }
     },
     "@aws-amplify/datastore": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-2.10.1.tgz",
-      "integrity": "sha512-6t3XygUPDdFbRRrn3kd11+8A30Mh7vzA2zdD+rwc39nZhgb/angmm2bpDSfC5t9tRftv0JBOkAaWOu6nxtLhKw==",
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-3.4.8.tgz",
+      "integrity": "sha512-uqHdjGT4hvAYsFA6m91pekYWT/z0D7sCpzjRJrKJB0gLGvCyIrVZTJP65l8+5IAFlnpcu9wrT/Y/EfiMjkkmtg==",
       "requires": {
-        "@aws-amplify/api": "3.3.3",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/pubsub": "3.3.3",
-        "amazon-cognito-identity-js": "4.6.3",
+        "@aws-amplify/api": "4.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/pubsub": "4.1.12",
+        "amazon-cognito-identity-js": "5.2.0",
         "idb": "5.0.6",
-        "immer": "8.0.1",
+        "immer": "9.0.6",
         "ulid": "2.3.0",
         "uuid": "3.3.2",
         "zen-observable-ts": "0.8.19",
         "zen-push": "0.2.1"
       },
       "dependencies": {
+        "immer": {
+          "version": "9.0.6",
+          "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+          "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
@@ -29724,41 +29726,24 @@
         "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-location": "3.22.0",
         "camelcase-keys": "6.2.2"
-      },
-      "dependencies": {
-        "@aws-amplify/core": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-4.3.2.tgz",
-          "integrity": "sha512-JHmAO3IyNoftFP6P2dNWTTs4mKGXcoFYoJQ7ONNWBmJq6RdWG8Ej/flP/42N8rhE7lA6qbY1AGuEl7QglJboDA==",
-          "requires": {
-            "@aws-crypto/sha256-js": "1.0.0-alpha.0",
-            "@aws-sdk/client-cloudwatch-logs": "3.6.1",
-            "@aws-sdk/client-cognito-identity": "3.6.1",
-            "@aws-sdk/credential-provider-cognito-identity": "3.6.1",
-            "@aws-sdk/types": "3.6.1",
-            "@aws-sdk/util-hex-encoding": "3.6.1",
-            "universal-cookie": "^4.0.4",
-            "zen-observable-ts": "0.8.19"
-          }
-        }
       }
     },
     "@aws-amplify/interactions": {
-      "version": "3.3.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-3.3.34.tgz",
-      "integrity": "sha512-152FEwVqtfJ8rDi0VGzqL4CSu44QCiRTHpKyacWMPcxdC6E0DtVdzcNgo94fenpJIQi2LyKuN8UZvK+NnMDENg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/interactions/-/interactions-4.0.20.tgz",
+      "integrity": "sha512-pC7eYqt0dJgwMg4kili0f2EsIEPWrpnoL4BKONOkeMR9oGwLgS1Vc1jrr7V0ILFQE2dF9bU9xWPZ9TlETQpDpg==",
       "requires": {
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-lex-runtime-service": "3.6.1"
       }
     },
     "@aws-amplify/predictions": {
-      "version": "3.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-3.2.34.tgz",
-      "integrity": "sha512-PObKVaW9sq3jnRpY85w6Ns38UItD66R0Yy+HsvcRfNBjIOOQT1bqvEEqLQZad0zP3hBSxnNGvdze4ye3oQZuwg==",
+      "version": "4.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-4.0.20.tgz",
+      "integrity": "sha512-J3Gza1NEtXeuQW1O41gj9bLkUgHIT6BHMcV07y4vAlMuU/DYnK4K9bnYDpKQQTkcByXaBz7A2ab+Hxb9JdYZdQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/storage": "3.4.4",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/storage": "4.4.3",
         "@aws-sdk/client-comprehend": "3.6.1",
         "@aws-sdk/client-polly": "3.6.1",
         "@aws-sdk/client-rekognition": "3.6.1",
@@ -29770,13 +29755,13 @@
       }
     },
     "@aws-amplify/pubsub": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-3.3.3.tgz",
-      "integrity": "sha512-j9PwkOjUhGE1cbExVjVfVeR7aMzlwckbP01K6QHPqOccstS/ZVD3W9ifhVCYJho1TTa6NoT7wn2HromesP2frQ==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-4.1.12.tgz",
+      "integrity": "sha512-CSEjOLlUaVceTwjfSdwWVWtQnzs0YScPmTwH3fUDdxRatEOOVYBckRhryygXIk/RzsDMCyMYwclxEy0ZtEE+GA==",
       "requires": {
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
         "graphql": "14.0.0",
         "paho-mqtt": "^1.1.0",
         "uuid": "^3.2.1",
@@ -29784,31 +29769,31 @@
       }
     },
     "@aws-amplify/storage": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-3.4.4.tgz",
-      "integrity": "sha512-Qwh3G0e1UiqDTMnKgkxpM7BPoL9FozfGc2m1yWGT+VFbmVBZmuQyo1p3ENVgIbghQ/TqLpj447mg0Xfl4bZ3cQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-4.4.3.tgz",
+      "integrity": "sha512-K6S8ZbHaXX8qLbL+Jbqx4AsJwBWfQMLSygYdF5Z5eUAAprOG3icwa1Th/y9UaZ1/wJNfzvjRu8VK3ToLlJcCyw==",
       "requires": {
-        "@aws-amplify/core": "3.8.24",
+        "@aws-amplify/core": "4.3.2",
         "@aws-sdk/client-s3": "3.6.1",
         "@aws-sdk/s3-request-presigner": "3.6.1",
         "@aws-sdk/util-create-request": "3.6.1",
         "@aws-sdk/util-format-url": "3.6.1",
-        "axios": "0.21.1",
+        "axios": "0.21.4",
         "events": "^3.1.0",
         "sinon": "^7.5.0"
       }
     },
     "@aws-amplify/ui": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.2.tgz",
-      "integrity": "sha512-OLdZmUCVK29+JV8PrkgVPjg+GIFtBnNjhC0JSRgrps+ynOFkibMQQPKeFXlTYtlukuCuepCelPSkjxvhcLq2ZA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/ui/-/ui-2.0.3.tgz",
+      "integrity": "sha512-LxbmPGD/S4bWzUh2PXMPSt/rXeUVJTsCbMpwH18XilTkXgOSmKH/eyVZNXUBY8C/xwqjzMTC68EtTlsM1DCq1A=="
     },
     "@aws-amplify/xr": {
-      "version": "2.2.34",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-2.2.34.tgz",
-      "integrity": "sha512-EooROlYAPQ6ty5lB7tRjXiXPtTIMsgDXidKUmNG8UPMbjbSYGQUVWA8TSYc18tJ/zYyiDYHCFH7MzIzv425FNQ==",
+      "version": "3.0.20",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/xr/-/xr-3.0.20.tgz",
+      "integrity": "sha512-Z3e6NdhkxE7Mu6LFgHOSsjz8aq/BGJ22wPqYg5vRD+dLQgTGCoHm88l8WFWMMensRqTer0+pn8fJWea7/biOcQ==",
       "requires": {
-        "@aws-amplify/core": "3.8.24"
+        "@aws-amplify/core": "4.3.2"
       }
     },
     "@aws-crypto/crc32": {
@@ -36661,12 +36646,12 @@
       "dev": true
     },
     "amazon-cognito-identity-js": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.6.3.tgz",
-      "integrity": "sha512-MPVJfirbdmSGo7l4h7Kbn3ms1eJXT5Xq8ly+mCPPi8yAxaxdg7ouMUUNTqtDykoZxIdDLF/P6F3Zbg3dlGKOWg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.2.0.tgz",
+      "integrity": "sha512-7nRkGb9Cinf1rD5t34B0NDWXO7lmyapXzLmSXq4IBOdiBMrmxToEHcRwfwT2jJfBWzzZiOS0gvQhKI32A+rmvg==",
       "requires": {
         "buffer": "4.9.2",
-        "crypto-js": "^4.0.0",
+        "crypto-js": "^4.1.1",
         "fast-base64-decode": "^1.0.0",
         "isomorphic-unfetch": "^3.0.0",
         "js-cookie": "^2.2.1"
@@ -37008,22 +36993,23 @@
       }
     },
     "aws-amplify": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-3.4.3.tgz",
-      "integrity": "sha512-eLWQ+2aLlnpWIK+5OGzlut9z/zZWcxVia4JOYbT3lrIMCsLRUZzqGioBsEg7XCggHSJMXIBkwLMMzuTZK/dQ1w==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-4.3.2.tgz",
+      "integrity": "sha512-p7et0uQvzQEebEk4yij/93wuozvUxSpufhFBpri5IuU0rQU0qHwb0bWEeIdtf93PrMbQcdeozfA82bSntvteEA==",
       "requires": {
-        "@aws-amplify/analytics": "4.0.22",
-        "@aws-amplify/api": "3.3.3",
-        "@aws-amplify/auth": "3.4.34",
-        "@aws-amplify/cache": "3.1.57",
-        "@aws-amplify/core": "3.8.24",
-        "@aws-amplify/datastore": "2.10.1",
-        "@aws-amplify/interactions": "3.3.34",
-        "@aws-amplify/predictions": "3.2.34",
-        "@aws-amplify/pubsub": "3.3.3",
-        "@aws-amplify/storage": "3.4.4",
-        "@aws-amplify/ui": "2.0.2",
-        "@aws-amplify/xr": "2.2.34"
+        "@aws-amplify/analytics": "5.1.0",
+        "@aws-amplify/api": "4.0.20",
+        "@aws-amplify/auth": "4.3.10",
+        "@aws-amplify/cache": "4.0.22",
+        "@aws-amplify/core": "4.3.2",
+        "@aws-amplify/datastore": "3.4.8",
+        "@aws-amplify/geo": "1.1.2",
+        "@aws-amplify/interactions": "4.0.20",
+        "@aws-amplify/predictions": "4.0.20",
+        "@aws-amplify/pubsub": "4.1.12",
+        "@aws-amplify/storage": "4.4.3",
+        "@aws-amplify/ui": "2.0.3",
+        "@aws-amplify/xr": "3.0.20"
       }
     },
     "axe-core": {
@@ -37033,11 +37019,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.10.0"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axobject-query": {
@@ -42211,7 +42197,8 @@
     "immer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
-      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
+      "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==",
+      "dev": true
     },
     "import-cwd": {
       "version": "2.1.0",

--- a/react-map-gl-amplify/package.json
+++ b/react-map-gl-amplify/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "license": "MIT-0",
   "dependencies": {
-    "@aws-amplify/geo": "^1.1.2",
-    "aws-amplify": "^3.4.3",
+    "aws-amplify": "^4.3.2",
     "maplibre-gl": "^1.15.2",
     "maplibre-gl-js-amplify": "^1.1.0",
     "react": "^17.0.1",

--- a/react-map-gl-amplify/src/index.tsx
+++ b/react-map-gl-amplify/src/index.tsx
@@ -21,8 +21,6 @@ import { TransformRequestFunction } from "maplibre-gl";
 
 // initialize Amplify (auth, etc.)
 Amplify.configure(awsconfig);
-// initialize Amplify Geo
-Geo.configure(awsconfig);
 
 const App = () => {
   const [credentials, setCredentials] = useState<ICredentials>();

--- a/react-map-gl-amplify/src/react-app-env.d.ts
+++ b/react-map-gl-amplify/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />


### PR DESCRIPTION
The old Amplify dependency wasn't pulling in `@aws-amplify/geo`, so the Amplify singleton seen by Geo (through `maplibre-gl-js-amplify` was different from the one loaded by the app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
