### PR TITLE
Add quick start app for web

### DIFF
--- a/maplibre-gl-js-quick-start/LICENSE
+++ b/maplibre-gl-js-quick-start/LICENSE
@@ -1,0 +1,15 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/maplibre-gl-js-quick-start/README.md
+++ b/maplibre-gl-js-quick-start/README.md
@@ -1,0 +1,22 @@
+# Quick Start Web App
+This example is a simple page that displays displays an interactive map and uses search functionality. [MapLibre GL JS](https://maplibre.org/maplibre-gl-js-docs/api/), [Amazon Location
+Service](https://aws.amazon.com/location), and [AWS Amplify](https://aws.amazon.com/amplify/) are used to build the app.
+
+See the [quick start guide](https://docs.aws.amazon.com/location/latest/developerguide/getting-started.html) for a complete walkthrough of this example.
+
+
+## Getting started
+1. Create Amazon Location resources for the app by following [these steps](https://docs.aws.amazon.com/location/latest/developerguide/getting-started.html#qs-create-resources).
+1. Set up authentication for the app by following [these steps](https://docs.aws.amazon.com/location/latest/developerguide/getting-started.html#qs-setup-authentication).
+1. Fill replace the values for `identityPoolId`, `mapName`, and `placesName` in [`main.js`](main.js#L5-L10) with the information from steps 1 and 2.
+1. Open [quickstart.html](quickstart.html) in a browser to run the app.
+
+
+## Security
+
+See [CONTRIBUTING](../CONTRIBUTING.md#security-issue-notifications) for more information.
+
+
+## License
+
+This library is licensed under the MIT-0 License. See the LICENSE file.

--- a/maplibre-gl-js-quick-start/main.css
+++ b/maplibre-gl-js-quick-start/main.css
@@ -1,0 +1,54 @@
+* {
+  box-sizing: border-box;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+body {
+  margin: 0;
+}
+
+header {
+  background: #000000;
+  padding: 0.5rem;
+}
+
+h1 {
+  margin: 0;
+  text-align: center;
+  font-size: 1.5rem;
+  color: #ffffff;
+}
+
+main {
+  display: flex;
+  min-height: calc(100vh - 94px);
+}
+
+#map {
+  flex: 1;
+}
+
+aside {
+  overflow-y: auto;
+  flex: 0 0 30%;
+  max-height: calc(100vh - 94px);
+  box-shadow: 0 1px 1px 0 #001c244d, 1px 1px 1px 0 #001c2426, -1px 1px 1px 0 #001c2426;
+  background: #f9f9f9;
+  padding: 1rem;
+}
+
+h2 {
+  margin: 0;
+}
+
+pre {
+  white-space: pre-wrap;
+  font-family: monospace;
+  color: #16191f;
+}
+
+footer {
+  background: #000000;
+  padding: 1rem;
+  color: #ffffff;
+}

--- a/maplibre-gl-js-quick-start/main.js
+++ b/maplibre-gl-js-quick-start/main.js
@@ -1,0 +1,109 @@
+// Use Signer from @aws-amplify/core
+const { Signer } = window.aws_amplify_core;
+
+// AWS Resources
+// Cognito:
+const identityPoolId = "<Identity Pool ID>";
+
+// Amazon Location Service:
+const mapName = "<Map Resource Name>";
+const placesName = "<Places Resource Name>";
+
+// Extract the region from the Identity Pool ID
+AWS.config.region = identityPoolId.split(":")[0];
+
+// Instantiate a Cognito-backed credential provider
+const credentials = new AWS.CognitoIdentityCredentials({
+  IdentityPoolId: identityPoolId,
+});
+
+// Sign requests made by MapLibre GL JS using AWS SigV4:
+function transformRequest(url, resourceType) {
+  if (resourceType === "Style" && !url.includes("://")) {
+    // Resolve to an AWS URL
+    url = `https://maps.geo.${AWS.config.region}.amazonaws.com/maps/v0/maps/${url}/style-descriptor`;
+  }
+
+  if (url.includes("amazonaws.com")) {
+    // Sign AWS requests (with the signature as part of the query string)
+    return {
+      url: Signer.signUrl(url, {
+        access_key: credentials.accessKeyId,
+        secret_key: credentials.secretAccessKey,
+        session_token: credentials.sessionToken,
+      }),
+    };
+  }
+
+  // If not amazonaws.com, falls to here without signing
+  return { url };
+}
+
+// Initialize a map
+async function initializeMap() {
+  // Load credentials and set them up to refresh
+  await credentials.getPromise();
+  
+  // Initialize the map
+  const mlglMap = new maplibregl.Map({
+    container: "map", // HTML element ID of map element
+    center: [-77.03674, 38.891602], // Initial map centerpoint
+    zoom: 16, // Initial map zoom
+    style: mapName,
+    transformRequest,
+  });
+
+  // Add navigation control to the top left of the map
+  mlglMap.addControl(new maplibregl.NavigationControl(), "top-left");
+  
+  return mlglMap;
+}
+
+async function main() {
+  // Initialize map and AWS SDK for Location Service:
+  const map = await initializeMap();
+  const location = new AWS.Location({credentials, region: AWS.config.region});
+
+  // Variable to hold marker that will be rendered on click
+  let marker;
+
+  // On mouse click, display marker and get results:
+  map.on("click", function(e) {
+    // Remove any existing marker
+    if(marker) {
+      marker.remove();
+    }
+
+    // Render a marker on clicked point
+    marker = new maplibregl.Marker()
+      .setLngLat([e.lngLat.lng, e.lngLat.lat])
+      .addTo(map);
+
+    // Set up parameters for search call
+    let params = {
+      IndexName: placesName,
+      Position: [e.lngLat.lng, e.lngLat.lat],
+      Language: "en",
+      MaxResults: "5"
+    };
+
+    // Search for results around clicked point
+    location.searchPlaceIndexForPosition(params, function(err, data) {
+      if (err) {
+        // Write JSON response error to HTML
+        document.querySelector("#response").textContent = JSON.stringify(err, undefined, 2);
+
+        // Display error in an alert box
+        alert("There was an error searching.");
+      } else {
+        // Write JSON response data to HTML
+        document.querySelector("#response").textContent = JSON.stringify(data, undefined, 2);
+
+        // Display place label in an alert box
+        alert(data.Results[0].Place.Label);
+      }
+    });
+  });
+}
+
+main();

--- a/maplibre-gl-js-quick-start/quickstart.html
+++ b/maplibre-gl-js-quick-start/quickstart.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Quick start tutorial</title>
+
+    <!-- Styles -->
+    <link href="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.css" rel="stylesheet" />
+    <link href="main.css" rel="stylesheet" />
+  </head>
+  
+  <body>
+    <header>
+      <h1>Quick start tutorial</h1>
+    </header>
+    <main>
+      <div id="map"></div>
+      <aside>
+        <h2>JSON Response</h2>
+        <pre id="response"></pre>
+      </aside>
+    </main>
+    <footer>This is a simple Amazon Location Service app. Pan and zoom. Click to see details about entities close to a point.</footer>
+    
+    <!-- JavaScript dependencies -->
+    <script src="https://unpkg.com/maplibre-gl@1.14.0/dist/maplibre-gl.js"></script>
+    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.1030.0.min.js"></script>
+    <script src="https://unpkg.com/@aws-amplify/core@3.7.0/dist/aws-amplify-core.min.js"></script>
+    
+    <!-- JavaScript for the app -->
+    <script src="main.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
Adding the quick start app for web built from [this page](https://docs.aws.amazon.com/location/latest/developerguide/getting-started.html) to allow users to download the completed app.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
