### PR TITLE
Fix tracker device popup coordinates

### DIFF
--- a/amplify-ui-geo-explore/src/components/trackers/DevicePositionHistory.js
+++ b/amplify-ui-geo-explore/src/components/trackers/DevicePositionHistory.js
@@ -71,9 +71,8 @@ const DevicePositionHistory = ({ deviceHistoryEntries }) => {
           <div className={styles.popup__content}>
             <div className={styles.popup__title}>{selectedHistoryPoint.DeviceId}</div>
             <div className={styles.popup__coordinates}>
-              {`${selectedHistoryPoint.Position[0].toFixed(
-                6
-              )}, ${selectedHistoryPoint.Position[0].toFixed(6)}`}
+              {`${selectedHistoryPoint.Position[1].toFixed(6)},
+              ${selectedHistoryPoint.Position[0].toFixed(6)}`}
             </div>
             <div className={styles.popup__item}>
               <div className={styles.popup__subtitle}>Reported Time</div>

--- a/amplify-ui-geo-explore/src/components/trackers/Devices.js
+++ b/amplify-ui-geo-explore/src/components/trackers/Devices.js
@@ -39,7 +39,7 @@ const SingleDevice = ({ device, selectedDevice, onChangeSelectedDevice, onViewDe
           <div className={styles.popup__content}>
             <div className={styles.popup__title}>{device.DeviceId}</div>
             <div className={styles.popup__coordinates}>
-              {`${device.Position[0].toFixed(6)}, ${device.Position[0].toFixed(6)}`}
+              {`${device.Position[1].toFixed(6)}, ${device.Position[0].toFixed(6)}`}
             </div>
             <div className={styles.popup__item}>
               <div className={styles.popup__subtitle}>Last Reported</div>


### PR DESCRIPTION
This fixes the the longitude in the tracker device popup being displayed twice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
