### PR TITLE
feat: add devServer config to work with Cloud9

### DIFF
--- a/amplify-ui-geo-explore/webpack.config.js
+++ b/amplify-ui-geo-explore/webpack.config.js
@@ -32,4 +32,7 @@ module.exports = {
       template: "./public/index.html",
     }),
   ],
+  devServer: {
+    allowedHosts: "all",
+  }
 };


### PR DESCRIPTION
The webpack config used in the `amplify-ui-geo-explore` was not allowing the sample to be viewed via the Cloud9 preview feature. This required a verbose workaround that involved modifying the security group of the Cloud9 instance.

This PR introduces a setting in the `webpack.config.js` file of the sample that allows the webpack dev server to be accessed by any host.

Give that this is a strictly development feature, the lax setting is acceptable.

See documentation for the [setting here](https://webpack.js.org/configuration/dev-server/#devserverallowedhosts).

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
