### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/create-custom-map-style/amplify/backend/geo/customStyleMap/customStyleMap-cloudformation-template.json
+++ b/create-custom-map-style/amplify/backend/geo/customStyleMap/customStyleMap-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/leaflet-amplify/amplify/backend/geo/mapcf4954c3/mapcf4954c3-cloudformation-template.json
+++ b/leaflet-amplify/amplify/backend/geo/mapcf4954c3/mapcf4954c3-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/openlayers-amplify/amplify/backend/geo/mapce7dbf38/mapce7dbf38-cloudformation-template.json
+++ b/openlayers-amplify/amplify/backend/geo/mapce7dbf38/mapce7dbf38-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/react-map-gl-amplify-here-map/amplify/backend/geo/map2bf94dcb/map2bf94dcb-cloudformation-template.json
+++ b/react-map-gl-amplify-here-map/amplify/backend/geo/map2bf94dcb/map2bf94dcb-cloudformation-template.json
@@ -191,7 +191,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [

--- a/react-map-gl-amplify-here-map/amplify/backend/geo/placeindex0e5572f7/placeindex0e5572f7-cloudformation-template.json
+++ b/react-map-gl-amplify-here-map/amplify/backend/geo/placeindex0e5572f7/placeindex0e5572f7-cloudformation-template.json
@@ -194,7 +194,7 @@
           ]
         },
         "Handler": "index.handler",
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Timeout": 300
       },
       "DependsOn": [


### PR DESCRIPTION
CloudFormation templates in amazon-location-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.